### PR TITLE
Properly set agent position

### DIFF
--- a/habitat/sims/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator.py
@@ -421,6 +421,10 @@ class HabitatSim(habitat.Simulator):
         state.position = position
         state.rotation = rotation
 
+        # NB: The agent state also contains the sensor states in _absolute_ coordinates.
+        # In order to set the agent's body to a specific location and have the sensors follow,
+        # we must not provide any state for the sensors.
+        # This will cause them to follow the agent's body
         state.sensor_states = dict()
 
         agent.set_state(state, reset_sensors)

--- a/habitat/sims/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator.py
@@ -420,7 +420,7 @@ class HabitatSim(habitat.Simulator):
         state = self.get_agent_state(agent_id)
         state.position = position
         state.rotation = rotation
-        
+
         state.sensor_states = dict()
 
         agent.set_state(state, reset_sensors)

--- a/habitat/sims/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator.py
@@ -420,6 +420,9 @@ class HabitatSim(habitat.Simulator):
         state = self.get_agent_state(agent_id)
         state.position = position
         state.rotation = rotation
+        
+        state.sensor_states = dict()
+
         agent.set_state(state, reset_sensors)
 
         self._check_agent_position(position, agent_id)


### PR DESCRIPTION
## Motivation and Context

The agent's state contains the absolute position of the sensors.  When we call `set_agent_state`, we just provide the position of the agent's body and expect the sensors to follow.  This PR simply doesn't provide any sensor states and things fall-back to behaving as they previously did.

## How Has This Been Tested

Moving some episode visualization code to be on master and caught this.

## Types of changes


- Bug fix (non-breaking change which fixes an issue)
