### PR TITLE
Fixes install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft habitat/utils/visualizations/assets

--- a/setup.py
+++ b/setup.py
@@ -40,4 +40,5 @@ if __name__ == "__main__":
         license=LICENSE,
         setup_requires=["pytest-runner"],
         tests_require=["pytest"],
+        include_package_data=True
     )

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,5 @@ if __name__ == "__main__":
         license=LICENSE,
         setup_requires=["pytest-runner"],
         tests_require=["pytest"],
-        include_package_data=True
+        include_package_data=True,
     )


### PR DESCRIPTION
## Motivation and Context

`pip install .` doesn't include the agent sprite, which leads to an error on `from habitat.utils.visualizations import maps`.  This PR adds the `habitat/utils/visualizations/assets` folder to the package data, alleviating this.

## How Has This Been Tested

```
python -c "from habitat.utils.visualizations import maps"
```

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
