### PR TITLE
correct pytest code for the vector env render

### DIFF
--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -226,10 +226,11 @@ def test_rl_vectorized_envs():
         new_height = int(np.ceil(np.sqrt(NUM_ENVS)))
         new_width = int(np.ceil(float(NUM_ENVS) / new_height))
         h, w, c = observations[0]['rgb'].shape
-        assert tiled_img.shape[0] == h * new_height \
-               and tiled_img.shape[1] == w * new_width \
-               and tiled_img.shape[2] == d, \
-            "vector env render is broken"
+        assert tiled_img.shape == (
+            h * new_height,
+            w * new_width,
+            c,
+        ), "vector env render is broken"
         
         if (i + 1) % configs[0].ENVIRONMENT.MAX_EPISODE_STEPS == 0:
             assert all(dones), "dones should be true after max_episode steps"

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -221,7 +221,16 @@ def test_rl_vectorized_envs():
         assert len(rewards) == num_envs
         assert len(dones) == num_envs
         assert len(infos) == num_envs
-        assert envs.render(mode="rgb_array") is not None, "vector env render is broken"
+        
+        tiled_img = envs.render(mode="rgb_array")
+        new_height = int(np.ceil(np.sqrt(NUM_ENVS)))
+        new_width = int(np.ceil(float(NUM_ENVS) / new_height))
+        h, w, d = observations[0]['rgb'].shape
+        assert tiled_img.shape[0] == h * new_height \
+               and tiled_img.shape[1] == w * new_width \
+               and tiled_img.shape[2] == d, \
+            "vector env render is broken"
+        
         if (i + 1) % configs[0].ENVIRONMENT.MAX_EPISODE_STEPS == 0:
             assert all(dones), "dones should be true after max_episode steps"
 

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -225,7 +225,7 @@ def test_rl_vectorized_envs():
         tiled_img = envs.render(mode="rgb_array")
         new_height = int(np.ceil(np.sqrt(NUM_ENVS)))
         new_width = int(np.ceil(float(NUM_ENVS) / new_height))
-        h, w, d = observations[0]['rgb'].shape
+        h, w, c = observations[0]['rgb'].shape
         assert tiled_img.shape[0] == h * new_height \
                and tiled_img.shape[1] == w * new_width \
                and tiled_img.shape[2] == d, \

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -221,17 +221,17 @@ def test_rl_vectorized_envs():
         assert len(rewards) == num_envs
         assert len(dones) == num_envs
         assert len(infos) == num_envs
-        
+
         tiled_img = envs.render(mode="rgb_array")
         new_height = int(np.ceil(np.sqrt(NUM_ENVS)))
         new_width = int(np.ceil(float(NUM_ENVS) / new_height))
-        h, w, c = observations[0]['rgb'].shape
+        h, w, c = observations[0]["rgb"].shape
         assert tiled_img.shape == (
             h * new_height,
             w * new_width,
             c,
         ), "vector env render is broken"
-        
+
         if (i + 1) % configs[0].ENVIRONMENT.MAX_EPISODE_STEPS == 0:
             assert all(dones), "dones should be true after max_episode steps"
 

--- a/test/test_habitat_env.py
+++ b/test/test_habitat_env.py
@@ -221,9 +221,7 @@ def test_rl_vectorized_envs():
         assert len(rewards) == num_envs
         assert len(dones) == num_envs
         assert len(infos) == num_envs
-        assert envs.render(
-            mode="rgb_array"
-        ).all(), "vector env render is broken"
+        assert envs.render(mode="rgb_array") is not None, "vector env render is broken"
         if (i + 1) % configs[0].ENVIRONMENT.MAX_EPISODE_STEPS == 0:
             assert all(dones), "dones should be true after max_episode steps"
 


### PR DESCRIPTION
## Motivation and Context

`envs.render(mode="rgb_array")` actually returns a numpy array, so using the function `all()` is problematic, which will simply check if there is `0` in the array. 

Instead, we check if the size of the tiled image matches the expected size, making it same as what `tile_images()` does.

## How Has This Been Tested

```
pytest test/test_habitat_env.py
=================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.6.8, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: /private/home/xinwang1/workspace/habitat-api, inifile: setup.cfg
collected 10 items

test/test_habitat_env.py .........s                                                                                                                                                                                                                                                 [100%]
================================================================================================================================= short test summary info =================================================================================================================================
SKIPPED [1] test/test_habitat_env.py:328: unconditional skip

========================================================================================================================== 9 passed, 1 skipped in 68.75 seconds ===========================================================================================================================
```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
