### PR TITLE
Static PointGoal Sensor test

### DIFF
--- a/habitat/config/default.py
+++ b/habitat/config/default.py
@@ -37,6 +37,12 @@ _C.TASK.POINTGOAL_SENSOR = CN()
 _C.TASK.POINTGOAL_SENSOR.TYPE = "PointGoalSensor"
 _C.TASK.POINTGOAL_SENSOR.GOAL_FORMAT = "POLAR"
 # -----------------------------------------------------------------------------
+# # STATIC POINTGOAL SENSOR
+# -----------------------------------------------------------------------------
+_C.TASK.STATIC_POINTGOAL_SENSOR = CN()
+_C.TASK.STATIC_POINTGOAL_SENSOR.TYPE = "StaticPointGoalSensor"
+_C.TASK.STATIC_POINTGOAL_SENSOR.GOAL_FORMAT = "CARTESIAN"
+# -----------------------------------------------------------------------------
 # # HEADING SENSOR
 # -----------------------------------------------------------------------------
 _C.TASK.HEADING_SENSOR = CN()

--- a/habitat/tasks/nav/nav_task.py
+++ b/habitat/tasks/nav/nav_task.py
@@ -233,7 +233,7 @@ class StaticPointGoalSensor(habitat.Sensor):
         return "static_pointgoal"
 
     def _get_sensor_type(self, *args: Any, **kwargs: Any):
-        return SensorTypes.STATIC_GOAL_VECTOR
+        return SensorTypes.PATH
 
     def _get_observation_space(self, *args: Any, **kwargs: Any):
         if self._goal_format == "CARTESIAN":

--- a/test/test_sensors.py
+++ b/test/test_sensors.py
@@ -14,7 +14,7 @@ from habitat.config.default import get_config
 from habitat.tasks.nav.nav_task import (
     NavigationEpisode,
     COLLISION_PROXIMITY_TOLERANCE,
-    NavigationGoal
+    NavigationGoal,
 )
 from habitat.sims.habitat_simulator import SimulatorActions
 
@@ -116,8 +116,8 @@ def test_collisions():
     config.freeze()
     env = habitat.Env(config=config, dataset=None)
     env.reset()
-    random.seed(100)
-    np.random.seed(100)
+    random.seed(123)
+    np.random.seed(123)
 
     actions = [
         SimulatorActions.FORWARD.value,

--- a/test/test_sensors.py
+++ b/test/test_sensors.py
@@ -166,8 +166,6 @@ def test_static_pointgoal_sensor():
     config.TASK.SENSORS = ["STATIC_POINTGOAL_SENSOR"]
     config.freeze()
     env = habitat.Env(config=config, dataset=None)
-    random.seed(123)
-    np.random.seed(123)
 
     # start position is checked for validity for the specific test scene
     valid_start_position = [-1.3731, 0.08431, 8.60692]


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->
  * Fix a bug that overrides configs in `test_sensors.py`, now `test_sensor.py` depends on default config instead of `habitat_all_sensors_test.yaml`
  * Change default config in `habitat/config/default.py` to include static pointgoal sensor
  * Change `StaticPointGoalSensor._get_sensor_type()` return type to  `SensorTypes.PATH` from `SensorTypes.STATIC_GOAL_VECTOR`, since `STATIC_GOAL_VECTOR` does not yet exist.
## How Has This Been Tested
  * Add `test_static_pointgoal_sensor()` in `test/test_sensor.py` to test the changes above as well as the functionality of static point goal sensor
  * pytest summary:

```
test/test_baseline_agents.py ..                                          [  4%]
test/test_config.py ..                                                   [  9%]
test/test_dataset.py .........                                           [ 31%]
test/test_habitat_env.py ..........s                                     [ 58%]
test/test_habitat_example.py ...                                         [ 65%]
test/test_install.py .                                                   [ 68%]
test/test_mp3d_eqa.py sss                                                [ 75%]
test/test_pointnav_dataset.py .ss.                                       [ 85%]
test/test_sensors.py ....                                                [ 95%]
test/test_trajectory_sim.py ..                                           [100%]

==================== 35 passed, 6 skipped in 149.86 seconds ====================
```

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
