### PR TITLE
Fixes and upgrades the collision logic

### DIFF
--- a/habitat/core/simulator.py
+++ b/habitat/core/simulator.py
@@ -366,3 +366,13 @@ class Simulator:
 
     def close(self) -> None:
         raise NotImplementedError
+
+    @property
+    def previous_step_collided(self):
+        r"""Whether or not the previous step resulted in a collision
+
+        Returns:
+            bool: True if the previous step resulted in a collision, false otherwise
+
+        """
+        raise NotImplementedError

--- a/habitat/sims/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator.py
@@ -263,6 +263,7 @@ class HabitatSim(Simulator):
         if self._update_agents_state():
             sim_obs = self._sim.get_sensor_observations()
 
+        self._prev_sim_obs = sim_obs
         self._is_episode_active = True
         return self._sensor_suite.get_observations(sim_obs)
 
@@ -505,4 +506,15 @@ class HabitatSim(Simulator):
 
     @property
     def previous_step_collided(self):
+        r"""Whether or not the previous step resulted in a collision
+
+        Returns:
+            bool: True if the previous step resulted in a collision, false otherwise
+
+        Warning:
+            This feild is only updated when :meth:`step`, :meth:`reset`, or :meth:`get_observations_at` are
+            called.  It does not update when the agent is moved to a new loction.  Furthermore, it
+            will _always_ be false after :meth:`reset` or :meth:`get_observations_at` as neither of those
+            result in an action (step) being taken.
+        """
         return self._prev_sim_obs.get("collided", False)

--- a/habitat/sims/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator.py
@@ -69,9 +69,10 @@ class HabitatSimRGBSensor(RGBSensor):
 
     def get_observation(self, sim_obs):
         obs = sim_obs.get(self.uuid, None)
+        check_sim_obs(obs, self)
+
         # remove alpha channel
         obs = obs[:, :, :RGBSENSOR_DIMENSION]
-        check_sim_obs(obs, self)
         return obs
 
 
@@ -277,6 +278,8 @@ class HabitatSim(Simulator):
         else:
             sim_obs = self._sim.step(action)
 
+        self._prev_sim_obs = sim_obs
+
         observations = self._sensor_suite.get_observations(sim_obs)
         return observations
 
@@ -471,6 +474,9 @@ class HabitatSim(Simulator):
         success = self.set_agent_state(position, rotation, reset_sensors=False)
         if success:
             sim_obs = self._sim.get_sensor_observations()
+
+            self._prev_sim_obs = sim_obs
+
             observations = self._sensor_suite.get_observations(sim_obs)
             if not keep_agent_at_new_pose:
                 self.set_agent_state(
@@ -496,3 +502,7 @@ class HabitatSim(Simulator):
 
     def island_radius(self, position):
         return self._sim.pathfinder.island_radius(position)
+
+    @property
+    def previous_step_collided(self):
+        return self._prev_sim_obs.get("collided", False)

--- a/habitat/tasks/nav/nav_task.py
+++ b/habitat/tasks/nav/nav_task.py
@@ -26,7 +26,6 @@ from habitat.core.utils import not_none_validator
 from habitat.tasks.utils import cartesian_to_polar, quaternion_rotate_vector
 from habitat.utils.visualizations import maps
 
-COLLISION_PROXIMITY_TOLERANCE: float = 1e-3
 MAP_THICKNESS_SCALAR: int = 1250
 
 
@@ -396,12 +395,7 @@ class Collisions(Measure):
         if self._metric is None:
             self._metric = 0
 
-        current_position = self._sim.get_agent_state().position
-        if (
-            action == self._sim.index_forward_action
-            and self._sim.distance_to_closest_obstacle(current_position)
-            < COLLISION_PROXIMITY_TOLERANCE
-        ):
+        if self._sim.previous_step_collided:
             self._metric += 1
 
 

--- a/habitat_baselines/slambased/path_planners.py
+++ b/habitat_baselines/slambased/path_planners.py
@@ -1,9 +1,9 @@
+import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-import matplotlib.pyplot as plt
 from habitat_baselines.slambased.utils import generate_2dgrid
 
 

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
+
 from habitat.core.dataset import Dataset, Episode
 
 


### PR DESCRIPTION
## Motivation and Context

The current collision logic is kinda buggy and won't scale to arbitrary actions.  This PR uses https://github.com/facebookresearch/habitat-sim/pull/70 to detect collisions, which will hopefully be less buggy and scale to arbitrary actions!

@abhiskk @mathfac -- The API for using this is kinda weird as whether a collision occurred or not is calculated when a step happens and cannot easily be recalculated :/

## How Has This Been Tested

Lots and lots and lots of invocations of `pytest`

## Types of changes
- New feature (non-breaking change which adds functionality)

