### PR TITLE
Add helper function for mapping between action spaces

### DIFF
--- a/habitat/utils/__init__.py
+++ b/habitat/utils/__init__.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-# Copyright (c) Facebook, Inc. and its affiliates.
+
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 from habitat.utils import geometry_utils
+from habitat.utils.action_space_mapping import *
 
 __all__ = ["visualizations", "geometry_utils"]

--- a/habitat/utils/__init__.py
+++ b/habitat/utils/__init__.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-
+# Copyright (c) Facebook, Inc. and its affiliates.
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+
 from habitat.utils import geometry_utils
 from habitat.utils.action_space_mapping import *
 

--- a/habitat/utils/action_space_mapping.py
+++ b/habitat/utils/action_space_mapping.py
@@ -1,0 +1,121 @@
+from typing import Dict
+
+import numpy as np
+
+
+def build_mapping_matrix(mapping: Dict[int, int]) -> np.ndarray:
+    r"""Creates a matrix to map probabilities from one action space to another
+
+    Params:
+        mapping (Dict[int, int]):  The mapping between action spaces.  Keys in the dictionary
+            are the index in the current action space and the corresponding value is the action
+            index in the new action space
+
+    Returns:
+        (np.ndarray): Matrix to map between action spaces
+
+
+    Usage::
+        
+        # Mapping between stop on 3 and stop on 0
+        mapping = {0: 1, 1: 2, 2: 3, 3: 0}
+        probs = np.random.randn(8, 4)
+        probs /= probs.sum(-1)
+
+        new_probs = probs @ build_mapping_matrix(mapping)
+    """
+
+    d1 = max(list(mapping.values())) + 1
+    d0 = max(list(mapping.keys())) + 1
+    assert d0 == len(mapping), "All indices in the source must be mapped"
+    assert (
+        d1 >= d0
+    ), "The destination action space must be at least the same size as the source"
+
+    mapping_matrix = np.zeros((d0, d1), dtype=np.float32)
+    for k, v in mapping.items():
+        mapping_matrix[k, v] = 1.0
+
+    return mapping_matrix
+
+
+def _map_probs(mapping, probs, use_torch):
+    mapping_matrix = build_mapping_matrix(mapping)
+    if use_torch:
+        import torch
+
+        assert torch.is_tensor(probs)
+        mapping_matrix = torch.from_numpy(mapping_matrix).to(
+            device=probs.device, dtype=probs.dtype
+        )
+
+    return probs @ mapping_matrix
+
+
+def _map_logits(mapping, logits, use_torch):
+    mapping_matrix = build_mapping_matrix(mapping)
+
+    if use_torch:
+        import torch
+
+        assert torch.is_tensor(logits)
+        assert logits.dtype == torch.float32
+        mapping_matrix = torch.from_numpy(mapping_matrix).to(
+            device=logits.device, dtype=logits.dtype
+        )
+
+        mask = torch.ones_like(logits) @ mapping_matrix
+        flmin = torch.full(
+            (logits.size(0), mask.size(1)),
+            np.finfo(np.float32).min,
+            dtype=logits.dtype,
+            device=logits.device,
+        )
+    else:
+        mask = np.ones_like(logits) @ mapping_matrix
+        flmin = np.full(
+            (logits.shape[0], mask.shape[1]), np.finfo(np.float32).min
+        )
+
+    return logits @ mapping_matrix + (1.0 - mask) * flmin
+
+
+def map_action_distribution(
+    mapping: Dict[int, int], *, probs=None, logits=None, use_torch=False
+):
+    r"""Maps probabilities or logits from one action space to another.
+
+    Params:
+        mapping (Dict[int, int]):  The mapping between action spaces.  Keys in the dictionary
+            are the index in the current action space and the corresponding value is the action
+            index in the new action space
+        logits: The logits to map, mutually exclusive with probs.  
+            If the destinate action space is larger than the source action space, the unspecified logits
+            are set to the minimal floating point value.
+        probs: The probs to map, mutually exclusive with logits
+        use_torch (bool): Whether or not to use PyTorch.  If true, this operation is differentiable!
+
+    Returns:
+        The mapped probs or logits
+
+
+    Usage::
+        
+        # Mapping between stop on 3 and stop on 0
+        mapping = {0: 1, 1: 2, 2: 3, 3: 0}
+        probs = np.random.randn(8, 4)
+        probs /= probs.sum(-1)
+
+        new_probs = map_action_distribution(mapping, probs=probs)
+
+        logits = np.random.randn(8, 4)
+        new_logits = map_action_distribution(mapping, logits=logits)
+
+    """
+    assert probs is not None or logits is not None
+    assert probs is None or logits is None
+
+    if probs is not None:
+        return _map_probs(mapping, probs, use_torch)
+    else:
+        return _map_logits(mapping, logits, use_torch)

--- a/test/test_action_mapping.py
+++ b/test/test_action_mapping.py
@@ -11,7 +11,6 @@ except ImportError:
     has_torch = False
 
 
-
 def test_mapping_matrix():
     mapping = {0: 1, 1: 2, 2: 3, 3: 4}
     gt_matrix = np.zeros((4, 5), dtype=np.float32)

--- a/test/test_action_mapping.py
+++ b/test/test_action_mapping.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pytest
+
+import habitat.utils
+
+try:
+    import torch
+
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+
+
+def test_mapping_matrix():
+    mapping = {0: 1, 1: 2, 2: 3, 3: 4}
+    gt_matrix = np.zeros((4, 5), dtype=np.float32)
+    gt_matrix[0, 1] = 1
+    gt_matrix[1, 2] = 1
+    gt_matrix[2, 3] = 1
+    gt_matrix[3, 4] = 1
+
+    assert (habitat.utils.build_mapping_matrix(mapping) == gt_matrix).all()
+
+
+@pytest.mark.parametrize("use_torch", [(True,), (False,)])
+def test_mapping_probs(use_torch):
+    if use_torch and not has_torch:
+        pytest.skip("Test requires torch")
+
+    mapping = {0: 1, 1: 2, 2: 3, 3: 4}
+    if use_torch:
+        curr_probs = torch.rand(2, 4)
+        curr_probs /= curr_probs.sum(-1, keepdim=True)
+        expected_probs = torch.zeros(2, 5)
+
+        device = (
+            torch.device("cuda")
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        curr_probs = curr_probs.to(device)
+        expected_probs = expected_probs.to(device)
+    else:
+        curr_probs = np.random.randn(2, 4)
+        curr_probs /= curr_probs.sum(-1)
+        expected_probs = np.zeros(2, 5)
+
+    for k, v in mapping.items():
+        expected_probs[:, v] = curr_probs[:, k]
+
+    mapped_probs = habitat.utils.map_action_distribution(
+        mapping, probs=curr_probs, use_torch=use_torch
+    )
+
+    assert (mapped_probs - expected_probs).norm() < 1e-3
+
+
+@pytest.mark.parametrize("use_torch", [(True,), (False,)])
+def test_mapping_logits(use_torch):
+    if use_torch and not has_torch:
+        pytest.skip("Test requires torch")
+
+    mapping = {0: 1, 1: 2, 2: 3, 3: 4}
+    if use_torch:
+        curr_logits = torch.rand(2, 4)
+        expected_logits = torch.full((2, 5), np.finfo(np.float32).min)
+
+        device = (
+            torch.device("cuda")
+            if torch.cuda.is_available()
+            else torch.device("cpu")
+        )
+        curr_logits = curr_logits.to(device)
+        expected_logits = expected_logits.to(device)
+    else:
+        curr_logits = np.random.randn(2, 4)
+        expected_logits = np.full((2, 5), np.finfo(np.float32).min)
+
+    for k, v in mapping.items():
+        expected_logits[:, v] = curr_logits[:, k]
+
+    mapped_logits = habitat.utils.map_action_distribution(
+        mapping, logits=curr_logits, use_torch=use_torch
+    )
+
+    assert (mapped_logits - expected_logits).norm() < 1e-3


### PR DESCRIPTION
## Motivation and Context

We recently re-order our action number, which breaks checkpoints :(  This PR adds a helper function to help with mapping from the old action space to the new action space.  The help function maps on the level of probabilities or logits as this is more general and differentiable, making it also compatible with imitation learning.

## How Has This Been Tested

Via tests and applying this to our depth-PPO baselines.  On master, that baselines gets an SPL of 0, using this mapping, it gets 0.58 SPL (which is what it gets on the leaderboard).

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

