### PR TITLE
Expose measurements in NavRLEnv.get_info()

### DIFF
--- a/habitat_baselines/train_ppo.py
+++ b/habitat_baselines/train_ppo.py
@@ -86,12 +86,7 @@ class NavRLEnv(habitat.RLEnv):
         return done
 
     def get_info(self, observations):
-        info = {}
-
-        if self.get_done(observations):
-            info["spl"] = self.habitat_env.get_metrics()["spl"]
-
-        return info
+        return self.habitat_env.get_metrics()
 
 
 def make_env_fn(config_env, config_baseline, rank):


### PR DESCRIPTION
## Motivation and Context
Currently NavRLEnv.get_info() in train_ppo.py only ever returns spl. Fixed to return other measurements such as top_down_map or collisions, if specified.
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
