### PR TITLE
Fix the citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you use the Habitat platform in your research, please cite the following [tec
 ```
 @article{habitat19arxiv,
   title =   {Habitat: A Platform for Embodied AI Research},
-  author =  {Manolis Savva, Abhishek Kadian, Oleksandr Maksymets, Yili Zhao, Erik Wijmans, Bhavana Jain, Julian Straub, Jia Liu, Vladlen Koltun, Jitendra Malik, Devi Parikh and Dhruv Batra},
+  author =  {{Manolis Savva*} and {Abhishek Kadian*} and {Oleksandr Maksymets*} and Yili Zhao and Erik Wijmans and Bhavana Jain and Julian Straub and Jia Liu and Vladlen Koltun and Jitendra Malik and Devi Parikh and Dhruv Batra},
   journal = {arXiv preprint arXiv:1904.01201},
   year =    {2019}
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To this end, we aim to standardize the entire ‘software stack’ for training 
 If you use the Habitat platform in your research, please cite the following [technical report](https://arxiv.org/abs/1904.01201):
 ```
 @article{habitat19arxiv,
-  title =   {Habitat: A Platform for Embodied AI Research},
+  title =   {Habitat: {A} {P}latform for {E}mbodied {AI} {R}esearch},
   author =  {{Manolis Savva*} and {Abhishek Kadian*} and {Oleksandr Maksymets*} and Yili Zhao and Erik Wijmans and Bhavana Jain and Julian Straub and Jia Liu and Vladlen Koltun and Jitendra Malik and Devi Parikh and Dhruv Batra},
   journal = {arXiv preprint arXiv:1904.01201},
   year =    {2019}


### PR DESCRIPTION
## Motivation and Context

Our bibtex is wrong.  `,` is used to denote `last, first` format while `and` is used to separate authors. I also added caps

## How Has This Been Tested

With my eyes

Current:
![image](https://user-images.githubusercontent.com/12722529/59316656-6465d100-8c74-11e9-9d60-f5b37b97b4d4.png)


After:
![image](https://user-images.githubusercontent.com/12722529/59316620-35e7f600-8c74-11e9-9a3e-dbebb709cd8d.png)


