### PR TITLE
Limit requirements finding scope

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,9 @@ BASELINE_PATH = ["habitat_baselines", "habitat_baselines.*"]
 DEFAULT_EXCLUSION = ["test", "examples"]
 FULL_REQUIREMENTS = set()
 # collect requirements.txt file in all subdirectories
-for file_name in glob.glob("**/requirements.txt", recursive=True):
+for file_name in ["requirements.txt"] + glob.glob(
+    "habitat_baselines/**/requirements.txt", recursive=True
+):
     with open(file_name) as f:
         reqs = f.read()
         FULL_REQUIREMENTS.update(reqs.strip().split("\n"))


### PR DESCRIPTION
## Motivation and Context
Fix #131 . Now besides the main requirements.txt file, setup.py will only look for `requirements.txt` files in habitat_baselines modules. 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
