### PR TITLE
Update Habitat-API to allow for no rendering sensors

### DIFF
--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -189,13 +189,6 @@ class HabitatSim(Simulator):
             sim_sensor_cfg.sensor_type = sensor.sim_sensor_type  # type: ignore
             sensor_specifications.append(sim_sensor_cfg)
 
-        # If there is no sensors specified create a dummy sensor so simulator
-        # won't throw an error
-        if not _sensor_suite.sensors.values():
-            sim_sensor_cfg = habitat_sim.SensorSpec()
-            sim_sensor_cfg.resolution = [1, 1]
-            sensor_specifications.append(sim_sensor_cfg)
-
         agent_config.sensor_specifications = sensor_specifications
         agent_config.action_space = registry.get_action_space_configuration(
             self.config.ACTION_SPACE_CONFIG


### PR DESCRIPTION
## Motivation and Context

https://github.com/facebookresearch/habitat-sim/pull/85 adds the ability to load-up habitat-sim with no sensors.  This PR removes the shim from habitat-api that was needed when we didn't allow for no sensors!

## How Has This Been Tested

The no-sensor test passes :)

(It will fail on the CI until the corresponding PR on the sim is landed)

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

