### PR TITLE
fix multiprocess eval

### DIFF
--- a/habitat_baselines/evaluate_ppo.py
+++ b/habitat_baselines/evaluate_ppo.py
@@ -188,7 +188,10 @@ def eval_checkpoint(checkpoint_path, args, writer, cur_ckpt_idx=0):
         envs_to_pause = []
         n_envs = envs.num_envs
         for i in range(n_envs):
-            if next_episodes[i].episode_id in stats_episodes:
+            if (
+                next_episodes[i].scene_id,
+                next_episodes[i].episode_id,
+            ) in stats_episodes:
                 envs_to_pause.append(i)
 
             # episode ended
@@ -200,7 +203,7 @@ def eval_checkpoint(checkpoint_path, args, writer, cur_ckpt_idx=0):
                 current_episode_reward[i] = 0
                 # use scene_id + episode_id as unique id for storing stats
                 stats_episodes[
-                    "{}:{}".format(
+                    (
                         current_episodes[i].scene_id,
                         current_episodes[i].episode_id,
                     )

--- a/habitat_baselines/evaluate_ppo.py
+++ b/habitat_baselines/evaluate_ppo.py
@@ -198,8 +198,13 @@ def eval_checkpoint(checkpoint_path, args, writer, cur_ckpt_idx=0):
                 episode_stats["success"] = int(infos[i]["spl"] > 0)
                 episode_stats["reward"] = current_episode_reward[i].item()
                 current_episode_reward[i] = 0
-                stats_episodes[current_episodes[i].episode_id] = episode_stats
-
+                # use scene_id + episode_id as unique id for storing stats
+                stats_episodes[
+                    "{}:{}".format(
+                        current_episodes[i].scene_id,
+                        current_episodes[i].episode_id,
+                    )
+                ] = episode_stats
                 if args.video_option:
                     generate_video(
                         args,

--- a/habitat_baselines/evaluate_ppo.py
+++ b/habitat_baselines/evaluate_ppo.py
@@ -156,7 +156,7 @@ def eval_checkpoint(checkpoint_path, args, writer, cur_ckpt_idx=0):
         rgb_frames = [[]] * args.num_processes
         os.makedirs(args.video_dir, exist_ok=True)
 
-    while len(stats_episodes) < args.count_test_episodes:
+    while len(stats_episodes) < args.count_test_episodes and envs.num_envs > 0:
         current_episodes = envs.current_episodes()
 
         with torch.no_grad():


### PR DESCRIPTION
## Motivation and Context

Fix issue #149, now evaluate_ppo will correctly run and output stats with more than one processes (given that there are scenes to split on).
Improved stats recording : stats are handled in a per-episode way and aggregated at the end of the eval run. 
It is still recommended to use single process for eval with test_scenes since its val split currently does not support split-by-scene and all work will be done in one of the N processes. 
Thank you @erikwijmans for raising this issue.

Edit:
Also fix `cuDNN error: CUDNN_STATUS_BAD_PARAM` issue in #148. Now eval will work as long as there are enough episodes with unique `(scene_id, episode_id)` combo (but not necessarily unique episode_id). 

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
All tests pass and evaluate_ppo won't break with num_processes > 1. 
## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->

- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
