### PR TITLE
Adapt to habitat-sim Python bindings updates

### DIFF
--- a/examples/new_actions.py
+++ b/examples/new_actions.py
@@ -39,7 +39,8 @@ def _strafe_impl(
     noise_amount: float,
 ):
     forward_ax = (
-        scene_node.absolute_transformation()[0:3, 0:3] @ habitat_sim.geo.FRONT
+        np.array(scene_node.absolute_transformation().rotation_scaling())
+        @ habitat_sim.geo.FRONT
     )
     strafe_angle = np.deg2rad(strafe_angle)
     strafe_angle = np.random.uniform(


### PR DESCRIPTION
## Motivation and Context

This does the necessary adaptation to facebookresearch/habitat-sim#64 -- this was the only failure in habitat-sim's CI tests (for reference: https://circleci.com/gh/facebookresearch/habitat-sim/351).

## How Has This Been Tested

This change is done equivalently to changes in habitat-sim's `examples/new_actions.py` ([facebookresearch/habitat-sim@7f9111c3](https://github.com/facebookresearch/habitat-sim/commit/7f9111c3cb0c54e3d532cd269baf81b9c104a1e2#diff-c35c0400bd0f1a540ebc42bb3834399eL78)). And the CI seems to be happy :tada: 

## Types of changes

- [x] Docs change / refactoring / dependency upgrade