### PR TITLE
Dataset change: envs access episodes via iterator

### DIFF
--- a/habitat/core/dataset.py
+++ b/habitat/core/dataset.py
@@ -10,6 +10,7 @@ of a ``habitat.Agent`` inside ``habitat.Env``.
 """
 import copy
 import json
+from itertools import cycle
 from typing import Callable, Dict, Generic, List, Optional, Type, TypeVar
 
 import attr
@@ -88,6 +89,16 @@ class Dataset(Generic[T]):
             list of episodes corresponding to indexes.
         """
         return [self.episodes[episode_id] for episode_id in indexes]
+
+    def get_episode_iterator(self):
+        r"""
+        Creates and returns an iterator that iterates through self.episodes
+        in the desirable way specified.
+        Returns:
+            iterator for episodes
+        """
+        # TODO: support shuffling between epoch and  scene switching
+        return cycle(self.episodes)
 
     def to_json(self) -> str:
         class DatasetJSONEncoder(json.JSONEncoder):

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -200,3 +200,11 @@ def test_sample_episodes():
     dataset = _construct_dataset(10000)
     with pytest.raises(Exception):
         dataset.sample_episodes(10001)
+
+
+def test_iterator_looping():
+    dataset = _construct_dataset(100)
+    episode_iter = dataset.get_episode_iterator()
+    for i in range(200):
+        episode = next(episode_iter)
+        assert episode.episode_id == dataset.episodes[i % 100].episode_id

--- a/test/test_pointnav_dataset.py
+++ b/test/test_pointnav_dataset.py
@@ -124,7 +124,7 @@ def check_shortest_path(env, episode):
         len(episode.shortest_paths) == 1
     ), "Episode has no shortest paths or more than one."
 
-    env.episodes = [episode]
+    env.episode_iterator = iter([episode])
     env.reset()
     start_state = env.sim.get_agent_state()
     check_state(start_state, episode.start_position, episode.start_rotation)
@@ -165,7 +165,7 @@ def test_pointnav_episode_generator():
     ):
         episodes.append(episode)
     assert len(episodes) == 2 * NUM_EPISODES
-    env.episodes = episodes
+    env.episode_iterator = iter(episodes)
 
     for episode in episodes:
         check_shortest_path(env, episode)

--- a/test/test_sensors.py
+++ b/test/test_sensors.py
@@ -25,15 +25,17 @@ def _random_episode(env, config):
         0,
         np.cos(random_heading / 2),
     ]
-    env.episodes = [
-        NavigationEpisode(
-            episode_id="0",
-            scene_id=config.SIMULATOR.SCENE,
-            start_position=random_location,
-            start_rotation=random_rotation,
-            goals=[],
-        )
-    ]
+    env.episode_iterator = iter(
+        [
+            NavigationEpisode(
+                episode_id="0",
+                scene_id=config.SIMULATOR.SCENE,
+                start_position=random_location,
+                start_rotation=random_rotation,
+                goals=[],
+            )
+        ]
+    )
 
 
 def test_heading_sensor():
@@ -56,15 +58,17 @@ def test_heading_sensor():
             0,
             np.cos(random_heading / 2),
         ]
-        env.episodes = [
-            NavigationEpisode(
-                episode_id="0",
-                scene_id=config.SIMULATOR.SCENE,
-                start_position=[03.00611, 0.072447, -2.67867],
-                start_rotation=random_rotation,
-                goals=[],
-            )
-        ]
+        env.episode_iterator = iter(
+            [
+                NavigationEpisode(
+                    episode_id="0",
+                    scene_id=config.SIMULATOR.SCENE,
+                    start_position=[03.00611, 0.072447, -2.67867],
+                    start_rotation=random_rotation,
+                    goals=[],
+                )
+            ]
+        )
 
         obs = env.reset()
         heading = obs["heading"]
@@ -167,15 +171,17 @@ def test_static_pointgoal_sensor():
     # corresponds to simulator using z-negative as forward action
     start_rotation = [0, 0, 0, 1]
 
-    env.episodes = [
-        NavigationEpisode(
-            episode_id="0",
-            scene_id=config.SIMULATOR.SCENE,
-            start_position=valid_start_position,
-            start_rotation=start_rotation,
-            goals=[NavigationGoal(position=goal_position)],
-        )
-    ]
+    env.episode_iterator = iter(
+        [
+            NavigationEpisode(
+                episode_id="0",
+                scene_id=config.SIMULATOR.SCENE,
+                start_position=valid_start_position,
+                start_rotation=start_rotation,
+                goals=[NavigationGoal(position=goal_position)],
+            )
+        ]
+    )
 
     non_stop_actions = [
         act
@@ -211,15 +217,17 @@ def test_get_observations_at():
     # corresponds to simulator using z-negative as forward action
     start_rotation = [0, 0, 0, 1]
 
-    env.episodes = [
-        NavigationEpisode(
-            episode_id="0",
-            scene_id=config.SIMULATOR.SCENE,
-            start_position=valid_start_position,
-            start_rotation=start_rotation,
-            goals=[NavigationGoal(position=goal_position)],
-        )
-    ]
+    env.episode_iterator = iter(
+        [
+            NavigationEpisode(
+                episode_id="0",
+                scene_id=config.SIMULATOR.SCENE,
+                start_position=valid_start_position,
+                start_rotation=start_rotation,
+                goals=[NavigationGoal(position=goal_position)],
+            )
+        ]
+    )
     non_stop_actions = [
         act
         for act in range(env.action_space.n)


### PR DESCRIPTION
## Motivation and Context
This PR makes environments access episodes via an iterator instead of keeping a list of episodes, and is the first a series of Dataset improvements. The main motivation is that we want to customize how episodes are iterated by environment, and this should be handled by a iterator of Dataset class instead of the Env class. 
Now we can modify the iterator logic to change how envs iterate through episodes. It's also a little bit less costly for environments to keep one iterator plus one episode than a list of episodes.  

Potential use cases of such iterator (that will be supported later): 1.  shuffle episodes when all episodes have been trained once. 2. switch to episodes of different scenes when an environment is trained on episodes from the same scene for too long to prevent overfitting.

Roadmap of Dataset update:
1. Make envs take iterator. (this PR)
2. Add options for creating iterator (scene switching, shuffling, seeding).
3. (Remove environments' access to episode list, left intact for now for backward compatibility).
4. Make PointNav dataset detect scenes with `\scene-datasets` (current must have `content_scene_folder`).
4. Make dataset object splittable by scene, and replace [this logic](https://github.com/facebookresearch/habitat-api/blob/782f1f9aec09895dc27347927f01998ba383b8b4/habitat_baselines/train_ppo.py#L110-L134).

## How Has This Been Tested
All tests pass/skip. Some tests are modified to use iterator instead of list of episodes. One new test of iterator is added. 

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
