### PR TITLE
Added requirements install step for sim installation in CI setup.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,11 +117,13 @@ jobs:
               then
                 git clone https://github.com/facebookresearch/habitat-sim.git
                 cd habitat-sim
+                pip install -r requirements.txt --progress-bar off
                 python setup.py install --headless
               else
                 if [ ! -f ~/miniconda/pip_deps_installed ]
                 then
                   cd habitat-sim
+                  pip install -r requirements.txt --progress-bar off
                   python setup.py install --headless
                 fi
               fi


### PR DESCRIPTION
## Motivation and Context
Added requirements install step for sim installation in CI setup to fix CI build.
During CI run lately we get an error during quaternion dependency installation:
```
AttributeError: 'dict' object has no attribute '__NUMPY_SETUP__'
```
I checked that the error happens also on old commit in master that was passing before.
The fix here is to install simulator python dependencies through the pip.
The error is also related to issue https://github.com/facebookresearch/habitat-sim/issues/95.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
