### PR TITLE
Disable tensorboard to avoid VectorEnv error on closing

### DIFF
--- a/habitat_baselines/config/pointnav/ppo_train_test.yaml
+++ b/habitat_baselines/config/pointnav/ppo_train_test.yaml
@@ -10,3 +10,4 @@ TRAINER:
       task_config: "configs/tasks/pointnav.yaml"
       num_updates: 10
       num_mini_batch: 1
+      tensorboard_dir: ""


### PR DESCRIPTION
## Motivation and Context
Currently enabling tensorboard will cause an issue upon `VectorEnv` deletion. When training/eval is completed and `VectorEnv`'s `__del__` function gets called, the connection between worker and master is already lost before the close command gets send into working env. This seems to be rooted from tensorboard's underlying async writer using and closing BytesIO. See the `Run api tests` section of [circle-ci test result](https://circleci.com/gh/facebookresearch/habitat-api/576?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) for this stealthy error. 

Working on a proper fix, but for now this will patch the CI test. 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
The [tiny run script](https://github.com/facebookresearch/habitat-api/blob/d3d6a5eb2fa8d1a0878e647e4f965834898af6cc/.circleci/config.yml#L199) in CI will finish properly. 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
