### PR TITLE
Make ppo_trainer eval use generalized metric

### DIFF
--- a/habitat_baselines/common/utils.py
+++ b/habitat_baselines/common/utils.py
@@ -120,7 +120,8 @@ def generate_video(
     images: List[np.ndarray],
     episode_id: int,
     checkpoint_idx: int,
-    spl: float,
+    metric_name: str,
+    metric_value: float,
     tb_writer: TensorboardWriter,
     fps: int = 10,
 ) -> None:
@@ -132,7 +133,8 @@ def generate_video(
         images: list of images to be converted to video.
         episode_id: episode id for video naming.
         checkpoint_idx: checkpoint index for video naming.
-        spl: SPL for this episode for video naming.
+        metric_name: name of the performance metric, e.g. "spl".
+        metric_value: value of metric.
         tb_writer: tensorboard writer object for uploading video.
         fps: fps for generated video.
     Returns:
@@ -141,7 +143,7 @@ def generate_video(
     if len(images) < 1:
         return
 
-    video_name = f"episode{episode_id}_ckpt{checkpoint_idx}_spl{spl:.2f}"
+    video_name = f"episode{episode_id}_ckpt{checkpoint_idx}_{metric_name}{metric_value:.2f}"
     if "disk" in video_option:
         assert video_dir is not None
         images_to_video(images, video_dir, video_name)


### PR DESCRIPTION
## Motivation and Context
Making `eval()` in ppo_trainer retrieve the name (`sensor_uuid`) of performance metric used instead of always using `spl`. This change is necessary for ppo_trainer to support new tasks that might have performance metric other than `spl`. 
<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Tests pass.
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
