### PR TITLE
Manual control python demo

### DIFF
--- a/examples/agent_demo/__init__.py
+++ b/examples/agent_demo/__init__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/examples/agent_demo/demo_blind_agent.py
+++ b/examples/agent_demo/demo_blind_agent.py
@@ -1,0 +1,65 @@
+import torch
+import torch.nn as nn
+import os.path as osp
+
+
+class DemoBlindAgent(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.tgt_embed = nn.Linear(3, 32)
+        self.prev_action_embedding = nn.Embedding(5, 32)
+        self.lstm = nn.LSTM(64, 512, 2)
+        self.fc = nn.Linear(512, 4)
+
+        self.reset()
+
+        self.load_state_dict(
+            torch.load(osp.join(osp.dirname(__file__), "blind_agent_state.pth"))
+        )
+
+    def reset(self):
+        device = next(self.parameters()).device
+        self.hidden = (
+            torch.zeros(2, 1, 512, device=device),
+            torch.zeros(2, 1, 512, device=device),
+        )
+        self.prev_action = torch.full((1,), -1, dtype=torch.long, device=device)
+
+    def forward(self, obs):
+        if isinstance(obs, dict):
+            pg = obs["pointgoal"]
+        else:
+            pg = obs
+
+        if not torch.is_tensor(pg):
+            pg = torch.tensor(pg).to(
+                device=next(self.parameters()).device, dtype=torch.float32
+            )
+
+        if len(pg.size()) == 1:
+            pg = pg.unsqueeze(0)
+
+        with torch.no_grad():
+            pg = torch.stack([pg[:, 0], torch.cos(-pg[:, 1]), torch.sin(-pg[:, 1])], -1)
+
+            x = torch.cat(
+                [self.tgt_embed(pg), self.prev_action_embedding(self.prev_action + 1)],
+                -1,
+            )
+            x = x.unsqueeze(0)
+
+            x, self.hidden = self.lstm(x, self.hidden)
+
+            x = self.fc(x)
+            dist = torch.distributions.Categorical(logits=x)
+
+            self.prev_action = dist.sample().squeeze(-1)
+
+        return self.prev_action[0].item()
+
+
+if __name__ == "__main__":
+    obs = torch.randn(2)
+    blind_agent = DemoBlindAgent()
+    print(blind_agent(obs))
+    print(blind_agent(obs))

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -61,7 +61,7 @@ def transform_rgb_bgr(image):
 def display_instructions(image, instructions, size=1, offset=(0,0), fontcolor=(255,255,255)):
     for i,instruction in enumerate(instructions):
         x = offset[1]
-        y = offset[0] + (i+1)*size*50 - 15
+        y = offset[0] + int((i+1)*size*50) - 15
         font = cv2.FONT_HERSHEY_SIMPLEX
         cv2.putText(image, instruction, (x,y), font, size, fontcolor, 2, cv2.LINE_AA)
 
@@ -217,8 +217,8 @@ class Demo:
 
 
     def update(self, img, video_writer=None):
-        fontsize = 1
-        instructions_height = fontsize*50*len(self.instructions)
+        fontsize = 0.8
+        instructions_height = int(fontsize*50*len(self.instructions))
         instructions_img = np.zeros((instructions_height, img.shape[1], 3), np.uint8)
         display_instructions(instructions_img, self.instructions, size=fontsize)
         combined = np.vstack((instructions_img, img))
@@ -265,7 +265,7 @@ class Demo:
             self.update(img, video_writer)
 
         print("Episode finished after {} steps.".format(count_steps))
-        return actions
+        return actions, info
 
 
     def replay(self, actions, overlay_goal_radar=False, delay=1, video_writer=None):
@@ -302,10 +302,17 @@ class Demo:
     def demo(self, args):
         video_writer = None
         #video_writer = VideoWriter('test1.avi') if args.save_video else None
-        actions = self.run(overlay_goal_radar=args.overlay, show_map=args.show_map, video_writer=video_writer)
+        actions, info = self.run(overlay_goal_radar=args.overlay, show_map=args.show_map, video_writer=video_writer)
         #if video_writer is not None:
         #    video_writer.release()
         if not self.is_quit:
+            # Display info about how well you did
+            if info is not None:
+                success = info['spl'] > 0
+                if success:
+                    print("You succeeded!")
+                else:
+                    print("You failed!")    
             # Hack to get size of video 
             video_writer = VideoWriter('output.avi') if args.save_video else None
             self.replay(actions, overlay_goal_radar=args.overlay, delay=1, video_writer=video_writer)

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import cv2
+import habitat
+import math
+import numpy as np
+
+from typing import NamedTuple, Tuple
+
+class ActionKeyMapping(NamedTuple):
+    name: str
+    key: int
+    action_id: int
+    is_quit: bool = False
+
+AGENT_ACTION_KEYS = [
+    ActionKeyMapping("FORWARD", ord("w"), 0),
+    ActionKeyMapping("LEFT", ord("a"), 1),
+    ActionKeyMapping("RIGHT", ord("d"), 2),
+    ActionKeyMapping("DONE", ord(" "), 3),
+    ActionKeyMapping("QUIT", ord("q"), -1, True)
+]  
+
+class Rect(NamedTuple):
+    left: int
+    top: int
+    width: int
+    height: int
+
+    @property
+    def right(self):
+        return self.left + self.width
+
+    @property
+    def bottom(self):
+        return self.top + self.height
+
+    @property
+    def center(self):
+        return (self.left + int(self.width/2), self.top + int(self.height/2))    
+
+def transform_rgb_bgr(image):
+    return image[:, :, [2, 1, 0]]
+
+class ObsViewer:
+    def __init__(self, initial_observations, 
+            goal_display_size=128, overlay_goal=None):
+        self.window_name = "Habitat"
+        self.overlay_goal = overlay_goal
+
+        # What image sensors are active
+        all_image_sensors = ['rgb', 'depth'] 
+        self.active_image_sensors = [s for s in all_image_sensors if s in initial_observations]
+        total_width = 0
+        total_height = 0
+        for s in self.active_image_sensors:
+            total_width += initial_observations[s].shape[1]
+            total_height = max(initial_observations[s].shape[0], total_height)
+
+        self.draw_info = {}
+        if self.overlay_goal:
+            img = np.zeros((goal_display_size, goal_display_size, 3), np.uint8)
+            self.draw_info["pointgoal"] = { "image": img, "region": Rect(0,0,goal_display_size,goal_display_size) }
+        else:
+            side_img_height = max(total_height, goal_display_size)
+            self.side_img = np.zeros((side_img_height, goal_display_size, 3), np.uint8)
+            self.draw_info["pointgoal"] = { "image": self.side_img, "region": Rect(0,0,goal_display_size,goal_display_size) }
+            total_width += goal_display_size
+        self.window_size = (total_height, total_width)  
+
+    def show(self, observations):
+        img = self.draw_observations(observations)
+        cv2.imshow(self.window_name, img)
+
+    def draw_observations(self, observations):    
+        active_image_observations = [observations[s] for s in self.active_image_sensors]
+        for i,img in enumerate(active_image_observations):
+            if img.shape[2] == 1:
+                active_image_observations[i] = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+            elif img.shape[2] == 3:
+                active_image_observations[i] = transform_rgb_bgr(img)
+
+        # draw pointgoal
+        goal_draw_surface = self.draw_info['pointgoal']        
+        self.draw_pointgoal_polar(observations['pointgoal'], goal_draw_surface['image'], goal_draw_surface['region'], fov=90)
+        if self.overlay_goal:    
+            goal_region = goal_draw_surface['region']
+            bottom = self.window_size[0]
+            top = bottom - goal_region.height
+            left = self.window_size[1]//2 - goal_region.width//2
+            right = left + goal_region.width
+            stacked = np.hstack(active_image_observations)
+            overlay=cv2.addWeighted(stacked[top:bottom, left:right],0.5,goal_draw_surface['image'],0.5,0)
+            stacked[top:bottom, left:right] = overlay
+        else:
+            stacked = np.hstack(active_image_observations + [self.side_img])
+        return stacked
+
+    def draw_pointgoal_polar(self, pointgoal, img, 
+                    r: Rect, 
+                    fov=0,
+                    color=(0,0,255), wincolor=(0,0,0,0), 
+                    overlaycolor=(128,128,128), bgcolor=(255,255,255)):
+        angle = pointgoal[1]
+        mag = pointgoal[0]
+        nm = mag/(mag+1)
+        xy = (-math.sin(angle), -math.cos(angle))
+        size = int(round(0.45*min(r.width, r.height)))
+        center = r.center
+        target = (int(round(center[0]+xy[0]*size*nm)), int(round(center[1]+xy[1]*size*nm)))
+        cv2.rectangle(img,(r.left,r.top), (r.right,r.bottom), wincolor, -1)    # Fill with window color 
+        cv2.circle(img, center, size, bgcolor, -1)  # Circle with background color
+        if fov > 0:
+            masked = 360-fov
+            cv2.ellipse(img, center, (size,size), 90, -masked/2, masked/2, overlaycolor, -1) 
+        #print(center)
+        #print(target)
+        cv2.line(img, center, target, color, 1)
+        cv2.circle(img, target, 4, color, -1)
+
+def example(config, action_keys, args):
+    env = habitat.Env(
+        config=config
+    )
+
+    print("Environment creation successful")
+    observations = env.reset()
+    viewer = ObsViewer(observations, overlay_goal=args.overlay)
+    viewer.show(observations)
+
+    action_keys_map = {k.key : k for k in action_keys}
+    print("Agent stepping around inside environment.")
+    count_steps = 0
+    while not env.episode_over:
+        # observations = env.step(env.action_space.sample())
+        keystroke = cv2.waitKey(0)
+
+        action = action_keys_map.get(keystroke)
+        if action is not None:
+            print(action.name)
+            if action.is_quit:
+                break
+        else:
+            print("INVALID KEY")
+            continue
+
+        observations = env.step(action.action_id)
+        count_steps += 1
+
+        viewer.show(observations)
+
+    print(env.get_metrics())
+    print("Episode finished after {} steps.".format(count_steps))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Habitat API Example")
+    parser.add_argument("--task-config",
+                        default="configs/tasks/pointnav.yaml",
+                        help='Task configuration file for initializing a Habitat environment')
+    parser.add_argument("--overlay",
+                        default=False,
+                        action="store_true",
+                        help='Overlay pointgoal')
+    args = parser.parse_args()
+    opts = []
+    config = habitat.get_config(args.task_config.split(","), opts)
+    #print(config)
+    example(config, AGENT_ACTION_KEYS, args)

--- a/examples/gen_episodes.py
+++ b/examples/gen_episodes.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import random
+import os
+import sys
+
+import numpy as np
+
+from tqdm import tqdm
+
+import habitat
+import habitat.datasets.pointnav.pointnav_generator as pointnav_generator
+from habitat.sims import make_sim
+from habitat.config.default import get_config
+
+def generate_pointnav_dataset(config, num_episodes):
+    sim = make_sim(
+        id_sim=config.SIMULATOR.TYPE, config=config.SIMULATOR
+    )
+
+    sim.seed(config.SEED)
+    random.seed(config.SEED)
+    generator = pointnav_generator.generate_pointnav_episode(
+        sim=sim,
+        shortest_path_success_distance=config.TASK.SUCCESS_DISTANCE,
+        shortest_path_max_steps=config.ENVIRONMENT.MAX_EPISODE_STEPS,
+    )
+    episodes = []
+    for i in range(num_episodes):
+        print(f"Generating episode {i+1}/{num_episodes}")
+        episode = next(generator)
+        episodes.append(episode)
+
+    dataset = habitat.Dataset()
+    dataset.episodes = episodes
+    return dataset
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate episodes for habitat")
+    parser.add_argument("--task-config",
+                        default="configs/tasks/pointnav.yaml",
+                        help='Task configuration file for initializing a Habitat environment')
+    parser.add_argument("--scenes",
+                        help='Scenes')
+    parser.add_argument("-n", "--num_episodes",
+                        type=int,
+                        default=10,
+                        help='Number of episodes to generate')
+    parser.add_argument("-o", "--output",
+                        type=argparse.FileType('w'),
+                        default=sys.stdout,
+                        help='Output file for episodes')
+    args = parser.parse_args()
+    opts = []
+    config = habitat.get_config(args.task_config.split(","), opts)
+    dataset_type = config.DATASET.TYPE
+    if args.scenes is not None:
+        config.defrost()
+        config.SIMULATOR.SCENE = args.scenes
+        config.freeze()
+    print(config)
+    dataset = None
+    if dataset_type == "PointNav-v1":
+        dataset = generate_pointnav_dataset(config, args.num_episodes)
+    else:
+        print(f"Unknown dataset type: {dataset_type}")
+    if dataset is not None:
+        args.output.write(dataset.to_json())

--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -165,7 +165,7 @@ class Env:
         self._elapsed_steps = 0
         self._episode_over = False
 
-    def reset(self) -> Observations:
+    def reset(self, keep_current_episode=False) -> Observations:
         """Resets the environments and returns the initial observations.
 
         Returns:
@@ -175,13 +175,14 @@ class Env:
 
         assert len(self.episodes) > 0, "Episodes list is empty"
 
-        # Switch to next episode in a loop
-        if self._current_episode_index is None:
-            self._current_episode_index = 0
-        else:
-            self._current_episode_index = (
-                self._current_episode_index + 1
-            ) % len(self._episodes)
+        if not keep_current_episode:
+            # Switch to next episode in a loop        
+            if self._current_episode_index is None:
+                self._current_episode_index = 0
+            else:
+                self._current_episode_index = (
+                    self._current_episode_index + 1
+                ) % len(self._episodes)
         self.reconfigure(self._config)
 
         observations = self._sim.reset()
@@ -194,6 +195,7 @@ class Env:
         self._task.measurements.reset_measures(episode=self.current_episode)
 
         return observations
+
 
     def _update_step_stats(self) -> None:
         self._elapsed_steps += 1


### PR DESCRIPTION
## Motivation and Context
This PR introduces a demo that allows a user to run through a PointGoal navigation episode in the same way as trained agents, using keyboard controls.  The episode is then compared against oracle shortest path and a trained blind RL agent.

## How Has This Been Tested

Install Habitat-API as usual. Run `python examples/demo.py --task-config configs/tasks/pointnav.yaml --overlay` to get the following interactive view:
![image](https://user-images.githubusercontent.com/2142116/62988392-134f9600-bdf9-11e9-9683-f23b11247331.png)
Use the indicated keys to play and the `Q` key to exit.

Follow the instructions at the top of the `demo.py` file to run more advanced examples (e.g. `python examples/demo.py --task-config configs/tasks/pointnav.yaml,data/replica_demo/replica_test.yaml --agent blind --overlay --scenes-dir .` which will run an episode in a Replica scene)
The following interactive view will be opened
![image](https://user-images.githubusercontent.com/2142116/62988086-dafb8800-bdf7-11e9-88d7-0d69e41dcd67.png)

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- New feature (non-breaking change which adds functionality)

The only change in existing Habitat-API code was to allow the `Env.reset()` function to be called but keep the same episode instead of iterating forward (through a new `keep_current_episode` argument which defaults to false).

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
