### PR TITLE
Fixed bug with uneven splits for dataset.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,8 +150,7 @@ jobs:
       - run:
           name: Download test data
           command: |
-
-              if [ ! -d ./habitat-sim/data ]
+              if [ ! -f ./habitat-sim/data/scene_datasets/habitat-test-scenes/van-gogh-room.glb ]
               then
                 cd habitat-sim
                 wget http://dl.fbaipublicfiles.com/habitat/habitat-test-scenes.zip

--- a/test/test_dataset.py
+++ b/test/test_dataset.py
@@ -165,21 +165,25 @@ def test_get_splits_sort_by_episode_id():
                 assert ep.episode_id >= split.episodes[ii - 1].episode_id
 
 
+def check_uneven_splits(num_episodes: int, num_splits: int):
+    dataset = _construct_dataset(num_episodes)
+    splits = dataset.get_splits(num_splits, allow_uneven_splits=True)
+    assert len(splits) == num_splits
+    assert sum([len(split.episodes) for split in splits]) == num_episodes
+
+
 def test_get_uneven_splits():
+    check_uneven_splits(994, 64)
+    check_uneven_splits(1023, 64)
+    check_uneven_splits(1024, 64)
+    check_uneven_splits(1025, 64)
+    check_uneven_splits(10000, 9)
+    check_uneven_splits(10000, 10)
+
     dataset = _construct_dataset(10000)
     splits = dataset.get_splits(9, allow_uneven_splits=False)
     assert len(splits) == 9
     assert sum([len(split.episodes) for split in splits]) == (10000 // 9) * 9
-
-    dataset = _construct_dataset(10000)
-    splits = dataset.get_splits(9, allow_uneven_splits=True)
-    assert len(splits) == 9
-    assert sum([len(split.episodes) for split in splits]) == 10000
-
-    dataset = _construct_dataset(10000)
-    splits = dataset.get_splits(10, allow_uneven_splits=True)
-    assert len(splits) == 10
-    assert sum([len(split.episodes) for split in splits]) == 10000
 
 
 def test_sample_episodes():


### PR DESCRIPTION
## Motivation and Context
- when I use num_splits = 64, num_episodes = 994, stride is 16, last split_lengths is -14, Error "IndexError: list index out of range" occurs.
- Fixes https://github.com/facebookresearch/habitat-api/issues/191 created by @StOnEGiggity
- Fixed check if test data was loaded for CI

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
