### PR TITLE
Changed Shortest Path Follower criteria to use geodesic distance.

### DIFF
--- a/habitat/tasks/nav/shortest_path_follower.py
+++ b/habitat/tasks/nav/shortest_path_follower.py
@@ -69,7 +69,9 @@ class ShortestPathFollower:
         """Returns the next action along the shortest path.
         """
         if (
-            np.linalg.norm(goal_pos - self._sim.get_agent_state().position)
+            self._sim.geodesic_distance(
+                self._sim.get_agent_state().position, goal_pos
+            )
             <= self._goal_radius
         ):
             return self._get_return_value(SimulatorActions.STOP)


### PR DESCRIPTION
## Motivation and Context
- Changed Shortest Path Follower criteria to use geodesic distance.
- Fixes https://github.com/facebookresearch/habitat-api/issues/189.
- There is an opportunity to optimize speed and use called `get_straight_shortest_path_points` before, but that may require change of interface and gains will be insignificant, as `get_shortest_path` takes like 10 microseconds.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested
Pytest
<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
