### PR TITLE
Fix bug in env_utils

### DIFF
--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -87,7 +87,7 @@ def construct_envs(
         config.defrost()
         config.TASK_CONFIG = task_config
         config.freeze()
-        configs.append(config)
+        configs.append(config.clone())
 
     envs = habitat.VectorEnv(
         make_env_fn=make_env_fn,


### PR DESCRIPTION
## Motivation and Context

YACS config nodes are python objects, thus `cfgs = [cfg for _ in range(8)]` doesn't create 8 config nodes, but 8 pointers all to the same config node.  Then `cfgs[0].blah = blah2` will change the value of `blah` for all 8 configs nodes.  What you need to do is `cfgs = [cfg.clone() for _ in range(8)]`

## How Has This Been Tested

Manually

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

