### PR TITLE
Fix bug with RGB frames

### DIFF
--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -424,8 +424,8 @@ class PPOTrainer(BaseRLTrainer):
         stats_episodes = dict()  # dict of dicts that stores stats per episode
 
         rgb_frames = [
-            []
-        ] * self.config.NUM_PROCESSES  # type: List[List[np.ndarray]]
+            [] for _ in range(self.config.NUM_PROCESSES)
+        ]  # type: List[List[np.ndarray]]
         if len(self.config.VIDEO_OPTION) > 0:
             os.makedirs(self.config.VIDEO_DIR, exist_ok=True)
 


### PR DESCRIPTION
## Motivation and Context

Fix another bug like in #208.  Lists are also objects and `[[]] * 5` just creates a list of 5 pointers to the same thing.

## How Has This Been Tested

Locally
