### PR TITLE
Reenable fog of war

### DIFF
--- a/habitat/utils/visualizations/utils.py
+++ b/habitat/utils/visualizations/utils.py
@@ -176,7 +176,9 @@ def observations_to_image(observation: Dict, info: Dict) -> np.ndarray:
 
     if "top_down_map" in info:
         top_down_map = info["top_down_map"]["map"]
-        top_down_map = maps.colorize_topdown_map(top_down_map)
+        top_down_map = maps.colorize_topdown_map(
+            top_down_map, info["top_down_map"]["fog_of_war_mask"]
+        )
         map_agent_pos = info["top_down_map"]["agent_map_coord"]
         top_down_map = maps.draw_agent(
             image=top_down_map,


### PR DESCRIPTION
## Motivation and Context

The fog-of-war mask wasn't being passed to `maps.colorize_topdown_map` for some reason.  This fixes that.

## How Has This Been Tested

Locally

## Types of changes


- Bug fix (non-breaking change which fixes an issue)
