### PR TITLE
docs: separate public config with GA and improved search

### DIFF
--- a/docs/build-public.sh
+++ b/docs/build-public.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Propagate failures properly
+set -e
+
+mcss_path=../../habitat-sim/docs/m.css
+
+# Regenerate the compiled CSS file (yes, in the sim repository, to allow fast
+# iterations from here as well)
+$mcss_path/css/postprocess.py \
+  ../../habitat-sim/docs/theme.css \
+  $mcss_path/css/m-grid.css \
+  $mcss_path/css/m-components.css \
+  $mcss_path/css/m-layout.css \
+  ../../habitat-sim/docs/pygments-pastie.css \
+  $mcss_path/css/pygments-console.css \
+  $mcss_path/css/m-documentation.css \
+  -o ../../habitat-sim/docs/theme.compiled.css
+
+$mcss_path/documentation/python.py conf-public.py
+
+# The file:// URLs are usually clickable in the terminal, directly opening a
+# browser
+echo "------------------------------------------------------------------------"
+echo "Public docs were successfully generated to the following location. Note"
+echo "that the search functionality requires a web server in this case."
+echo
+echo "file://$(pwd)/../../habitat-sim/build/docs-public/habitat-api/index.html"

--- a/docs/conf-public.py
+++ b/docs/conf-public.py
@@ -1,0 +1,27 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
+# Inherit everything from the local config
+from conf import *  # isort:skip
+
+OUTPUT = "../../habitat-sim/build/docs-public/habitat-api/"
+
+HTML_HEADER = """<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-66408458-4"></script>
+<script>
+ window.dataLayer = window.dataLayer || [];
+ function gtag(){dataLayer.push(arguments);}
+ gtag('js', new Date());
+ gtag('config', 'UA-66408458-4');
+</script>
+"""
+
+SEARCH_DOWNLOAD_BINARY = "searchdata-v1.bin"
+SEARCH_BASE_URL = "https://aihabitat.org/docs/habitat-api/"
+SEARCH_EXTERNAL_URL = "https://google.com/search?q=site:aihabitat.org+{query}"


### PR DESCRIPTION
## Motivation and Context

As requested by @abhiskk. Adding GA tracking to the docs, but to avoid privacy issues in a local build, there's now a separate public config. Additionally, for the public version the search downloads a binary data (which is smaller, but won't work locally), plus also provides a helpful link to Google search if nothing is found.

## How Has This Been Tested

I pressed some keys and it made pixels shine in a correct way.