### PR TITLE
Fix contains method in space classes

### DIFF
--- a/habitat/core/spaces.py
+++ b/habitat/core/spaces.py
@@ -63,16 +63,12 @@ class ActionSpace(gym.spaces.Dict):
         }
 
     def contains(self, x):
-        if not isinstance(x, dict):
+        if not isinstance(x, dict) or "action" not in x:
             return False
-        if not all(key in x for key in {"action", "action_args"}):
-            return False
-
         if x["action"] not in self.spaces:
             return False
-        if not self.spaces[x["action"]].contains(x["action_args"]):
+        if not self.spaces[x["action"]].contains(x.get("action_args", None)):
             return False
-
         return True
 
     def __repr__(self):

--- a/habitat/core/spaces.py
+++ b/habitat/core/spaces.py
@@ -21,7 +21,12 @@ class EmptySpace(Space):
         return None
 
     def contains(self, x):
+        if x is None:
+            return True
         return False
+
+    def __repr__(self):
+        return "EmptySpace()"
 
 
 class ActionSpace(gym.spaces.Dict):
@@ -30,14 +35,13 @@ class ActionSpace(gym.spaces.Dict):
 
     .. code:: py
 
-        self.observation_space = spaces.ActionSpace(
+        self.observation_space = spaces.ActionSpace({
             "move": spaces.Dict({
                 "position": spaces.Discrete(2),
                 "velocity": spaces.Discrete(3)
-                },
-            "move_forward": EmptySpace,
-            )
-        )
+            }),
+            "move_forward": EmptySpace(),
+        })
     """
 
     def __init__(self, spaces):
@@ -59,10 +63,16 @@ class ActionSpace(gym.spaces.Dict):
         }
 
     def contains(self, x):
-        if not isinstance(x, dict) and {"action", "action_args"} not in x:
+        if not isinstance(x, dict):
+            return False
+        if not all(key in x for key in {"action", "action_args"}):
+            return False
+
+        if x["action"] not in self.spaces:
             return False
         if not self.spaces[x["action"]].contains(x["action_args"]):
             return False
+
         return True
 
     def __repr__(self):
@@ -100,7 +110,7 @@ class ListSpace(Space):
         if not isinstance(x, Sized):
             return False
 
-        if self.min_seq_length <= len(x) <= self.max_seq_length:
+        if len(x) < self.min_seq_length or len(x) > self.max_seq_length:
             return False
 
         return all([self.space.contains(el) for el in x])

--- a/habitat/core/spaces.py
+++ b/habitat/core/spaces.py
@@ -106,7 +106,7 @@ class ListSpace(Space):
         if not isinstance(x, Sized):
             return False
 
-        if len(x) < self.min_seq_length or len(x) > self.max_seq_length:
+        if not (self.min_seq_length <= len(x) <= self.max_seq_length):
             return False
 
         return all([self.space.contains(el) for el in x])

--- a/test/test_habitat_task.py
+++ b/test/test_habitat_task.py
@@ -13,8 +13,8 @@ import habitat
 from habitat.utils.test_utils import sample_non_stop_action
 
 CFG_TEST = "configs/test/habitat_all_sensors_test.yaml"
-TELEPORT_POSITION = [-3.2890449, 0.15067159, 11.124366]
-TELEPORT_ROTATION = [0.92035, 0, -0.39109465, 0]
+TELEPORT_POSITION = np.array([-3.2890449, 0.15067159, 11.124366])
+TELEPORT_ROTATION = np.array([0.92035, 0, -0.39109465, 0])
 
 
 def test_task_actions():
@@ -24,17 +24,16 @@ def test_task_actions():
     config.freeze()
 
     env = habitat.Env(config=config)
-    assert env.action_space.contains(env.action_space.sample())
     env.reset()
-    env.step(
-        action={
-            "action": "TELEPORT",
-            "action_args": {
-                "position": TELEPORT_POSITION,
-                "rotation": TELEPORT_ROTATION,
-            },
-        }
-    )
+    action={
+        "action": "TELEPORT",
+        "action_args": {
+            "position": TELEPORT_POSITION,
+            "rotation": TELEPORT_ROTATION,
+        },
+    }
+    assert env.action_space.contains(action)
+    env.step(action)
     agent_state = env.sim.get_agent_state()
     assert np.allclose(
         np.array(TELEPORT_POSITION, dtype=np.float32), agent_state.position
@@ -54,10 +53,10 @@ def test_task_actions_sampling_for_teleport():
     config.freeze()
 
     env = habitat.Env(config=config)
-    assert env.action_space.contains(env.action_space.sample())
     env.reset()
     while not env.episode_over:
         action = sample_non_stop_action(env.action_space)
+        assert env.action_space.contains(action)
         habitat.logger.info(
             f"Action : "
             f"{action['action']}, "
@@ -88,10 +87,10 @@ def test_task_actions_sampling(config_file):
         )
 
     env = habitat.Env(config=config)
-    assert env.action_space.contains(env.action_space.sample())
     env.reset()
     while not env.episode_over:
         action = sample_non_stop_action(env.action_space)
+        assert env.action_space.contains(action)
         habitat.logger.info(
             f"Action : "
             f"{action['action']}, "

--- a/test/test_habitat_task.py
+++ b/test/test_habitat_task.py
@@ -24,6 +24,7 @@ def test_task_actions():
     config.freeze()
 
     env = habitat.Env(config=config)
+    assert env.action_space.contains(env.action_space.sample())
     env.reset()
     env.step(
         action={
@@ -53,6 +54,7 @@ def test_task_actions_sampling_for_teleport():
     config.freeze()
 
     env = habitat.Env(config=config)
+    assert env.action_space.contains(env.action_space.sample())
     env.reset()
     while not env.episode_over:
         action = sample_non_stop_action(env.action_space)
@@ -86,6 +88,7 @@ def test_task_actions_sampling(config_file):
         )
 
     env = habitat.Env(config=config)
+    assert env.action_space.contains(env.action_space.sample())
     env.reset()
     while not env.episode_over:
         action = sample_non_stop_action(env.action_space)

--- a/test/test_habitat_task.py
+++ b/test/test_habitat_task.py
@@ -25,7 +25,7 @@ def test_task_actions():
 
     env = habitat.Env(config=config)
     env.reset()
-    action={
+    action = {
         "action": "TELEPORT",
         "action_args": {
             "position": TELEPORT_POSITION,

--- a/test/test_spaces.py
+++ b/test/test_spaces.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import gym
+import pytest
+
+from habitat.core.spaces import ActionSpace, EmptySpace, ListSpace
+
+
+def test_empty_space():
+    space = EmptySpace()
+    assert space.contains(space.sample())
+    assert space.contains(None)
+    assert not space.contains(0)
+
+
+def test_action_space():
+    space = ActionSpace(
+        {
+            "move": gym.spaces.Dict(
+                {
+                    "position": gym.spaces.Discrete(2),
+                    "velocity": gym.spaces.Discrete(3),
+                }
+            ),
+            "move_forward": EmptySpace(),
+        }
+    )
+    assert space.contains(space.sample())
+    assert space.contains(
+        {"action": "move", "action_args": {"position": 0, "velocity": 1}}
+    )
+    assert space.contains({"action": "move_forward"})
+    assert not space.contains([0, 1, 2])
+    assert not space.contains({"zero": None})
+    assert not space.contains({"action": "move"})
+    assert not space.contains(
+        {"action": "move", "action_args": {"position": 0}}
+    )
+    assert not space.contains(
+        {"action": "move_forward", "action_args": {"position": 0}}
+    )
+
+
+def test_list_space():
+    space = ListSpace(gym.spaces.Discrete(2), 5, 10)
+    assert space.contains(space.sample())
+    assert not space.contains([0] * 4)
+    assert not space.contains([2] * 5)
+    assert not space.contains([1] * 11)

--- a/test/test_spaces.py
+++ b/test/test_spaces.py
@@ -36,6 +36,7 @@ def test_action_space():
     assert space.contains({"action": "move_forward"})
     assert not space.contains([0, 1, 2])
     assert not space.contains({"zero": None})
+    assert not space.contains({"action": "bad"})
     assert not space.contains({"action": "move"})
     assert not space.contains(
         {"action": "move", "action_args": {"position": 0}}
@@ -48,6 +49,7 @@ def test_action_space():
 def test_list_space():
     space = ListSpace(gym.spaces.Discrete(2), 5, 10)
     assert space.contains(space.sample())
+    assert not space.contains(0)
     assert not space.contains([0] * 4)
     assert not space.contains([2] * 5)
     assert not space.contains([1] * 11)


### PR DESCRIPTION
## Motivation and Context

The `contains` methods in the three `habitat.core.spaces` classes (`EmptySpace`, `ActionSpace`, and `ListSpace`) have errors that are described in #271. This pull request fixes those errors, corrects the documentation for the `ActionSpace` class, and adds a `__repr__` to the `EmptySpace` class.

closes #271 

## How Has This Been Tested

This code was test by passing both valid and invalid samples to the `contains` method of instantiations of each of the three classes mentioned above.

## Types of changes

- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
