### PR TITLE
Make the defaults in the config better

### DIFF
--- a/habitat_baselines/README.md
+++ b/habitat_baselines/README.md
@@ -25,18 +25,19 @@ For training on sample data please follow steps in the repository README. You sh
 
 **train**:
 ```bash
-python -u habitat_baselines/run.py --exp-config habitat_baselines/config/pointnav/ppo_pointnav.yaml --run-type train
+python -u habitat_baselines/run.py --exp-config habitat_baselines/config/pointnav/ppo_pointnav_example.yaml --run-type train
 ```
 
 **test**:
 ```bash
-python -u habitat_baselines/run.py --exp-config habitat_baselines/config/pointnav/ppo_pointnav.yaml --run-type eval
+python -u habitat_baselines/run.py --exp-config habitat_baselines/config/pointnav/ppo_pointnav_example.yaml --run-type eval
 ```
 
 We also provide trained RGB, RGBD, Blind PPO models.
 To use them download pre-trained pytorch models from [link](https://dl.fbaipublicfiles.com/habitat/data/baselines/v1/habitat_baselines_v1.zip) and unzip and specify model path [here](agents/ppo_agents.py#L132).
 
-Change field `task_config` in `habitat_baselines/config/pointnav/ppo_pointnav.yaml` to `tasks/pointnav_mp3d.yaml` for training on [MatterPort3D point goal navigation dataset](/README.md#task-datasets).
+The `habitat_baselines/config/pointnav/ppo_pointnav.yaml` config has better hyperparamters for large scale training and loads the [Gibson PointGoal Navigation Dataset](/README.md#task-datasets) instead of the test scenes.
+Change the field `task_config` in `habitat_baselines/config/pointnav/ppo_pointnav.yaml` to `configs/tasks/pointnav_mp3d.yaml` for training on [MatterPort3D PointGoal Navigation Dataset](/README.md#task-datasets).
 
 ### Classic
 

--- a/habitat_baselines/config/pointnav/ppo_pointnav.yaml
+++ b/habitat_baselines/config/pointnav/ppo_pointnav.yaml
@@ -14,7 +14,10 @@ TEST_EPISODE_COUNT: 994
 EVAL_CKPT_PATH_DIR: "data/new_checkpoints"
 # This was 6 for mp3d and 8 for gibson in the paper
 NUM_PROCESSES: 4
-SENSORS: ["RGB_SENSOR", "DEPTH_SENSOR"]
+# Note:  To train the an RGB only model,
+# you may need to use 8 processes with 4 mini batches,
+# If so, the number of updates should be cut in half
+SENSORS: ["DEPTH_SENSOR"]
 CHECKPOINT_FOLDER: "data/new_checkpoints"
 NUM_UPDATES: 270000
 LOG_INTERVAL: 25

--- a/habitat_baselines/config/pointnav/ppo_pointnav.yaml
+++ b/habitat_baselines/config/pointnav/ppo_pointnav.yaml
@@ -6,8 +6,9 @@ TRAINER_NAME: "ppo"
 ENV_NAME: "NavRLEnv"
 SIMULATOR_GPU_ID: 0
 TORCH_GPU_ID: 0
-# VIDEO_OPTION: ["disk", "tensorboard"]
 VIDEO_OPTION: []
+# Can be uncommented to generate videos.
+# VIDEO_OPTION: ["disk", "tensorboard"]
 TENSORBOARD_DIR: "tb"
 VIDEO_DIR: "video_dir"
 TEST_EPISODE_COUNT: 994

--- a/habitat_baselines/config/pointnav/ppo_pointnav.yaml
+++ b/habitat_baselines/config/pointnav/ppo_pointnav.yaml
@@ -1,26 +1,32 @@
-BASE_TASK_CONFIG_PATH: "configs/tasks/pointnav.yaml"
+# Note:  Hyperparameters have been changed slightly from
+# the paper to allow for things to easily run on 1 GPU
+
+BASE_TASK_CONFIG_PATH: "configs/tasks/pointnav_gibson.yaml"
 TRAINER_NAME: "ppo"
 ENV_NAME: "NavRLEnv"
 SIMULATOR_GPU_ID: 0
 TORCH_GPU_ID: 0
-VIDEO_OPTION: ["disk", "tensorboard"]
+# VIDEO_OPTION: ["disk", "tensorboard"]
+VIDEO_OPTION: []
 TENSORBOARD_DIR: "tb"
 VIDEO_DIR: "video_dir"
-TEST_EPISODE_COUNT: 2
+TEST_EPISODE_COUNT: 994
 EVAL_CKPT_PATH_DIR: "data/new_checkpoints"
-NUM_PROCESSES: 1
+# This was 6 for mp3d and 8 for gibson in the paper
+NUM_PROCESSES: 4
 SENSORS: ["RGB_SENSOR", "DEPTH_SENSOR"]
 CHECKPOINT_FOLDER: "data/new_checkpoints"
-NUM_UPDATES: 10000
-LOG_INTERVAL: 10
-CHECKPOINT_INTERVAL: 50
+NUM_UPDATES: 270000
+LOG_INTERVAL: 25
+CHECKPOINT_INTERVAL: 2000
 
 RL:
   PPO:
     # ppo params
     clip_param: 0.1
     ppo_epoch: 4
-    num_mini_batch: 1
+    # This was 4 in the paper
+    num_mini_batch: 2
     value_loss_coef: 0.5
     entropy_coef: 0.01
     lr: 2.5e-4

--- a/habitat_baselines/config/pointnav/ppo_pointnav_example.yaml
+++ b/habitat_baselines/config/pointnav/ppo_pointnav_example.yaml
@@ -1,0 +1,36 @@
+BASE_TASK_CONFIG_PATH: "configs/tasks/pointnav.yaml"
+TRAINER_NAME: "ppo"
+ENV_NAME: "NavRLEnv"
+SIMULATOR_GPU_ID: 0
+TORCH_GPU_ID: 0
+VIDEO_OPTION: ["disk", "tensorboard"]
+TENSORBOARD_DIR: "tb"
+VIDEO_DIR: "video_dir"
+TEST_EPISODE_COUNT: 2
+EVAL_CKPT_PATH_DIR: "data/new_checkpoints"
+NUM_PROCESSES: 1
+SENSORS: ["RGB_SENSOR", "DEPTH_SENSOR"]
+CHECKPOINT_FOLDER: "data/new_checkpoints"
+NUM_UPDATES: 10000
+LOG_INTERVAL: 10
+CHECKPOINT_INTERVAL: 50
+
+RL:
+  PPO:
+    # ppo params
+    clip_param: 0.1
+    ppo_epoch: 4
+    num_mini_batch: 1
+    value_loss_coef: 0.5
+    entropy_coef: 0.01
+    lr: 2.5e-4
+    eps: 1e-5
+    max_grad_norm: 0.5
+    num_steps: 128
+    hidden_size: 512
+    use_gae: True
+    gamma: 0.99
+    tau: 0.95
+    use_linear_clip_decay: True
+    use_linear_lr_decay: True
+    reward_window_size: 50


### PR DESCRIPTION
## Motivation and Context

The default values in `ppo_pointnav.yaml` are nice as for a "just see if it runs" experiment, but are not well chosen for training something meaningful.  This PR changes the default values in `ppo_pointnav.yaml` to be closer to what was used in the paper (modified to work for 1 GPU).  The old `ppo_pointnav.yaml` is now `ppo_pointnav_example.yaml`

This is likely the issue in #281 .

## How Has This Been Tested

Locally.

## Types of changes



- Bug fix (non-breaking change which fixes an issue)

