### PR TITLE
Interface with habitat-sim no sliding

### DIFF
--- a/habitat/config/default.py
+++ b/habitat/config/default.py
@@ -247,6 +247,8 @@ _C.SIMULATOR.HABITAT_SIM_V0.GPU_DEVICE_ID = 0
 # Read here: https://pytorch.org/docs/stable/multiprocessing.html#sharing-cuda-tensors
 # for the caveats that results in
 _C.SIMULATOR.HABITAT_SIM_V0.GPU_GPU = False
+# Whether or not the agent slides on collisions
+_C.SIMULATOR.HABITAT_SIM_V0.ALLOW_SLIDING = True
 # -----------------------------------------------------------------------------
 # PYROBOT
 # -----------------------------------------------------------------------------

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -177,6 +177,7 @@ class HabitatSim(Simulator):
         sim_config = habitat_sim.SimulatorConfiguration()
         sim_config.scene.id = self.config.SCENE
         sim_config.gpu_device_id = self.config.HABITAT_SIM_V0.GPU_DEVICE_ID
+        sim_config.allow_sliding = self.config.HABITAT_SIM_V0.ALLOW_SLIDING
         agent_config = habitat_sim.AgentConfiguration()
         overwrite_config(
             config_from=self._get_agent_config(), config_to=agent_config


### PR DESCRIPTION
## Motivation and Context

Habitat sim can now disable sliding.  This PR wires up habitat-api with that.

## How Has This Been Tested

Current tests pass, the no sliding test on the simulator passes.  If you change sliding to false in habitat-api, some of the position dependent tests begin to fail :)

## Types of changes


- New feature (non-breaking change which adds functionality)


