### PR TITLE
Pass physics option to sim

### DIFF
--- a/habitat/config/default.py
+++ b/habitat/config/default.py
@@ -249,6 +249,10 @@ _C.SIMULATOR.HABITAT_SIM_V0.GPU_DEVICE_ID = 0
 _C.SIMULATOR.HABITAT_SIM_V0.GPU_GPU = False
 # Whether or not the agent slides on collisions
 _C.SIMULATOR.HABITAT_SIM_V0.ALLOW_SLIDING = True
+_C.SIMULATOR.HABITAT_SIM_V0.ENABLE_PHYSICS = False
+_C.SIMULATOR.HABITAT_SIM_V0.PHYSICS_CONFIG_FILE = (
+    "./data/default.phys_scene_config.json"
+)
 # -----------------------------------------------------------------------------
 # PYROBOT
 # -----------------------------------------------------------------------------

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -178,6 +178,10 @@ class HabitatSim(Simulator):
         sim_config.scene.id = self.config.SCENE
         sim_config.gpu_device_id = self.config.HABITAT_SIM_V0.GPU_DEVICE_ID
         sim_config.allow_sliding = self.config.HABITAT_SIM_V0.ALLOW_SLIDING
+        sim_config.enable_physics = self.config.HABITAT_SIM_V0.ENABLE_PHYSICS
+        sim_config.physics_config_file = (
+            self.config.HABITAT_SIM_V0.PHYSICS_CONFIG_FILE
+        )
         agent_config = habitat_sim.AgentConfiguration()
         overwrite_config(
             config_from=self._get_agent_config(), config_to=agent_config


### PR DESCRIPTION
See #277 for some discussion.

This new feature allows for habitat-api to start a physics-enabled `sim`. Tested by inserting objects from the habitat API. Ran `mypy` and `black` before commit.