### PR TITLE
Convert observations to float32 on the GPU

### DIFF
--- a/habitat_baselines/common/utils.py
+++ b/habitat_baselines/common/utils.py
@@ -96,8 +96,10 @@ def batch_obs(
             batch[sensor].append(_to_tensor(obs[sensor]))
 
     for sensor in batch:
-        batch[sensor] = torch.stack(batch[sensor], dim=0).to(
-            device=device, dtype=torch.float
+        batch[sensor] = (
+            torch.stack(batch[sensor], dim=0)
+            .to(device=device)
+            .to(dtype=torch.float)
         )
 
     return batch


### PR DESCRIPTION
## Motivation and Context

Reduce habitat baselines CPU usage by converting observations to float32 on the GPU (if a GPU is being used).

## How Has This Been Tested

With a little test script that just does

```python
import numpy as np
import torch


rgba = np.zeros((256, 256, 4), dtype=np.uint8)

while True:
    rgb = np.ascontiguousarray(rgba[..., 0:3])
    rgb = torch.from_numpy(rgb).to(device="cuda:0").to(dtype=torch.float32)
```

If you change it back to `to(device="cuda:0", dtype=torch.float32)`, CPU usage skyrockets to use all available cores.  With the fix, CPU usages stays at on core (instead of going up to the number of cores!).

## Types of changes


- Bug fix (non-breaking change which fixes an issue)
