### PR TITLE
De-duplicate goals for objectnav

### DIFF
--- a/configs/test/habitat_mp3d_object_nav_test.yaml
+++ b/configs/test/habitat_mp3d_object_nav_test.yaml
@@ -45,7 +45,7 @@ TASK:
 
 DATASET:
   TYPE: ObjectNav-v1
-  SPLIT: mini_val
-  CONTENT_SCENES: []
+  SPLIT: val
+  CONTENT_SCENES: ["*"]
   DATA_PATH: "data/datasets/objectnav/mp3d/v0/{split}/{split}.json.gz"
   SCENES_DIR: "data/scene_datasets/"

--- a/habitat/core/simulator.py
+++ b/habitat/core/simulator.py
@@ -206,28 +206,17 @@ class SensorSuite:
         return Observations(self.sensors, *args, **kwargs)
 
 
+@attr.s(auto_attribs=True)
 class AgentState:
     position: List[float]
-    rotation: Optional[List[float]]
-
-    def __init__(
-        self, position: List[float], rotation: Optional[List[float]]
-    ) -> None:
-        self.position = position
-        self.rotation = rotation
+    rotation: Optional[List[float]] = None
 
 
+@attr.s(auto_attribs=True)
 class ShortestPathPoint:
     position: List[Any]
     rotation: List[Any]
-    action: Optional[int]
-
-    def __init__(
-        self, position: List[Any], rotation: List[Any], action: Optional[int]
-    ) -> None:
-        self.position = position
-        self.rotation = rotation
-        self.action = action
+    action: Optional[int] = None
 
 
 class Simulator:

--- a/habitat/datasets/object_nav/object_nav_dataset.py
+++ b/habitat/datasets/object_nav/object_nav_dataset.py
@@ -41,14 +41,16 @@ class ObjectNavDatasetV1(PointNavDatasetV1):
 
         goals_by_category = dict()
         for i, ep in enumerate(dataset["episodes"]):
-            goals_key = "{}_{}".format(
-                ep["scene_id"], ep["goals"][0]["object_id"]
-            )
+            dataset["episodes"][i]["object_category"] = ep["goals"][0][
+                "object_category"
+            ]
+            ep = ObjectGoalNavEpisode(**ep)
+
+            goals_key = ep.goals_key
             if goals_key not in goals_by_category:
-                goals_by_category[goals_key] = ep["goals"]
+                goals_by_category[goals_key] = ep.goals
 
             dataset["episodes"][i]["goals"] = []
-            dataset["episodes"][i]["goals_key"] = goals_key
 
         dataset["goals_by_category"] = goals_by_category
 

--- a/habitat/datasets/object_nav/object_nav_dataset.py
+++ b/habitat/datasets/object_nav/object_nav_dataset.py
@@ -30,16 +30,13 @@ class ObjectNavDatasetV1(PointNavDatasetV1):
     content_scenes_path: str = "{data_path}/content/{scene}.json.gz"
 
     def to_json(self) -> str:
-        for ep in self.episodes:
-            ep.goals = str(ep.goals[0].object_id)
-
         self.goals_per_category = {}
         for i, ep in enumerate(self.episodes):
-            obj_id = str(ep.goals[0].object_id)
-            if obj_id not in self.goals_per_category:
-                self.goals_per_category[obj_id] = ep.goals
+            goals_id = "{}_{}".format(ep.scene_id, ep.goals[0].object_id)
+            if goals_id not in self.goals_per_category:
+                self.goals_per_category[goals_id] = ep.goals
 
-            self.episodes[i].goals = obj_id
+            self.episodes[i].goals = goals_id
 
         result = DatasetFloatJSONEncoder().encode(self)
 

--- a/habitat/datasets/object_nav/object_nav_dataset.py
+++ b/habitat/datasets/object_nav/object_nav_dataset.py
@@ -6,8 +6,9 @@
 
 import json
 import os
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
+from habitat.config import Config
 from habitat.core.registry import registry
 from habitat.core.simulator import AgentState, ShortestPathPoint
 from habitat.core.utils import DatasetFloatJSONEncoder
@@ -16,8 +17,11 @@ from habitat.datasets.pointnav.pointnav_dataset import (
     DEFAULT_SCENE_PATH_PREFIX,
     PointNavDatasetV1,
 )
-from habitat.tasks.nav.nav import NavigationEpisode
-from habitat.tasks.nav.object_nav_task import ObjectGoal, ObjectViewLocation
+from habitat.tasks.nav.object_nav_task import (
+    ObjectGoal,
+    ObjectGoalNavEpisode,
+    ObjectViewLocation,
+)
 
 
 @registry.register_dataset(name="ObjectNav-v1")
@@ -26,28 +30,57 @@ class ObjectNavDatasetV1(PointNavDatasetV1):
     """
     category_to_task_category_id: Dict[str, int]
     category_to_scene_annotation_category_id: Dict[str, int]
-    episodes: List[NavigationEpisode]
+    episodes: List[ObjectGoalNavEpisode]
     content_scenes_path: str = "{data_path}/content/{scene}.json.gz"
+    goals_by_category: Dict[str, List[ObjectGoal]]
+
+    @staticmethod
+    def dedup_goals(dset: Dict[str, Any]) -> Dict[str, Any]:
+        if len(dset["episodes"]) == 0:
+            return dset
+
+        goals_by_category = dict()
+        for i, ep in enumerate(dset["episodes"]):
+            goals_key = "{}_{}".format(
+                ep["scene_id"], ep["goals"][0]["object_id"]
+            )
+            if goals_key not in goals_by_category:
+                goals_by_category[goals_key] = ep["goals"]
+
+            dset["episodes"][i]["goals"] = []
+            dset["episodes"][i]["goals_key"] = goals_key
+
+        dset["goals_by_category"] = goals_by_category
+
+        return dset
 
     def to_json(self) -> str:
-        self.goals_per_category = {}
-        for i, ep in enumerate(self.episodes):
-            goals_id = "{}_{}".format(ep.scene_id, ep.goals[0].object_id)
-            if goals_id not in self.goals_per_category:
-                self.goals_per_category[goals_id] = ep.goals
-
-            self.episodes[i].goals = goals_id
+        for i in range(len(self.episodes)):
+            self.episodes[i].goals = []
 
         result = DatasetFloatJSONEncoder().encode(self)
 
         for i in range(len(self.episodes)):
-            self.episodes[i].goals = self.goals_per_category[
-                self.episodes[i].goals
+            self.episodes[i].goals = self.goals_by_category[
+                self.episodes[i].goals_key
             ]
 
-        del self.goals_per_category
-
         return result
+
+    def __init__(self, config: Optional[Config] = None) -> None:
+        self.goals_by_category = {}
+        super().__init__(config)
+
+    @staticmethod
+    def __deserialize_goal(serialized_goal: Dict[str, Any]) -> ObjectGoal:
+        g = ObjectGoal(**serialized_goal)
+
+        for vidx, view in enumerate(g.view_points):
+            view_location = ObjectViewLocation(**view)
+            view_location.agent_state = AgentState(**view_location.agent_state)
+            g.view_points[vidx] = view_location
+
+        return g
 
     def from_json(
         self, json_str: str, scenes_dir: Optional[str] = None
@@ -79,27 +112,18 @@ class ObjectNavDatasetV1(PointNavDatasetV1):
             self.category_to_scene_annotation_category_id.keys()
         ), "category_to_task and category_to_mp3d must have the same keys"
 
-        if not "goals_by_category" in deserialized:
-            if len(deserialized["episodes"]) == 0:
-                return
-            else:
-                raise RuntimeError("Episodes have no goals")
+        if len(deserialized["episodes"]) == 0:
+            return
 
-        goals_by_category = deserialized["goals_by_category"]
+        if "goals_by_category" not in deserialized:
+            deserialized = self.dedup_goals(deserialized)
 
-        for k, v in goals_by_category.items():
-            for i in range(len(v)):
-                v[i] = ObjectGoal(**v[i])
+        for k, v in deserialized["goals_by_category"].items():
+            self.goals_by_category[k] = [self.__deserialize_goal(g) for g in v]
 
-                for vidx, view in enumerate(v[i].view_points):
-                    view_location = ObjectViewLocation(**view)
-                    view_location.agent_state = AgentState(
-                        **view_location.agent_state
-                    )
-                    v[i].view_points[vidx] = view_location
-
-        for episode in deserialized["episodes"]:
-            episode = NavigationEpisode(**episode)
+        for i, episode in enumerate(deserialized["episodes"]):
+            episode = ObjectGoalNavEpisode(**episode)
+            episode.episode_id = str(i)
 
             if scenes_dir is not None:
                 if episode.scene_id.startswith(DEFAULT_SCENE_PATH_PREFIX):
@@ -109,19 +133,17 @@ class ObjectNavDatasetV1(PointNavDatasetV1):
 
                 episode.scene_id = os.path.join(scenes_dir, episode.scene_id)
 
-            episode.goals = goals_by_category[episode.goals]
+            episode.goals = self.goals_by_category[episode.goals_key]
 
             if episode.shortest_paths is not None:
                 for path in episode.shortest_paths:
                     for p_index, point in enumerate(path):
-                        point = {
-                            "action": point,
-                            "rotation": None,
-                            "position": None,
-                        }
+                        if isinstance(point, int) or point is None:
+                            point = {
+                                "action": point,
+                                "rotation": None,
+                                "position": None,
+                            }
                         path[p_index] = ShortestPathPoint(**point)
 
             self.episodes.append(episode)
-
-        for i, ep in enumerate(self.episodes):
-            ep.episode_id = str(i)

--- a/habitat/datasets/object_nav/object_nav_dataset.py
+++ b/habitat/datasets/object_nav/object_nav_dataset.py
@@ -79,6 +79,10 @@ class ObjectNavDatasetV1(PointNavDatasetV1):
             self.category_to_scene_annotation_category_id.keys()
         ), "category_to_task and category_to_mp3d must have the same keys"
 
+        if not "goals_by_category" in deserialized:
+            assert len(deserialized["episodes"]) == 0, "Episodes have no goals"
+            return
+
         goals_by_category = deserialized["goals_by_category"]
 
         for k, v in goals_by_category.items():

--- a/habitat/datasets/object_nav/object_nav_dataset.py
+++ b/habitat/datasets/object_nav/object_nav_dataset.py
@@ -35,24 +35,24 @@ class ObjectNavDatasetV1(PointNavDatasetV1):
     goals_by_category: Dict[str, List[ObjectGoal]]
 
     @staticmethod
-    def dedup_goals(dset: Dict[str, Any]) -> Dict[str, Any]:
-        if len(dset["episodes"]) == 0:
-            return dset
+    def dedup_goals(dataset: Dict[str, Any]) -> Dict[str, Any]:
+        if len(dataset["episodes"]) == 0:
+            return dataset
 
         goals_by_category = dict()
-        for i, ep in enumerate(dset["episodes"]):
+        for i, ep in enumerate(dataset["episodes"]):
             goals_key = "{}_{}".format(
                 ep["scene_id"], ep["goals"][0]["object_id"]
             )
             if goals_key not in goals_by_category:
                 goals_by_category[goals_key] = ep["goals"]
 
-            dset["episodes"][i]["goals"] = []
-            dset["episodes"][i]["goals_key"] = goals_key
+            dataset["episodes"][i]["goals"] = []
+            dataset["episodes"][i]["goals_key"] = goals_key
 
-        dset["goals_by_category"] = goals_by_category
+        dataset["goals_by_category"] = goals_by_category
 
-        return dset
+        return dataset
 
     def to_json(self) -> str:
         for i in range(len(self.episodes)):
@@ -138,12 +138,13 @@ class ObjectNavDatasetV1(PointNavDatasetV1):
             if episode.shortest_paths is not None:
                 for path in episode.shortest_paths:
                     for p_index, point in enumerate(path):
-                        if isinstance(point, int) or point is None:
+                        if point is None or isinstance(point, (int, str)):
                             point = {
                                 "action": point,
                                 "rotation": None,
                                 "position": None,
                             }
+
                         path[p_index] = ShortestPathPoint(**point)
 
             self.episodes.append(episode)

--- a/habitat/datasets/object_nav/object_nav_dataset.py
+++ b/habitat/datasets/object_nav/object_nav_dataset.py
@@ -80,8 +80,10 @@ class ObjectNavDatasetV1(PointNavDatasetV1):
         ), "category_to_task and category_to_mp3d must have the same keys"
 
         if not "goals_by_category" in deserialized:
-            assert len(deserialized["episodes"]) == 0, "Episodes have no goals"
-            return
+            if len(deserialized["episodes"]) == 0:
+                return
+            else:
+                raise RuntimeError("Episodes have no goals")
 
         goals_by_category = deserialized["goals_by_category"]
 

--- a/habitat/tasks/nav/object_nav_task.py
+++ b/habitat/tasks/nav/object_nav_task.py
@@ -23,6 +23,15 @@ from habitat.tasks.nav.nav import (
 )
 
 
+@attr.s(auto_attribs=True, kw_only=True)
+class ObjectGoalNavEpisode(NavigationEpisode):
+    r"""ObjectGoal Navigation Episode
+
+    :param goals_key: Key to retrieve goals with
+    """
+    goals_key: str = None
+
+
 @attr.s(auto_attribs=True)
 class ObjectViewLocation:
     r"""ObjectViewLocation provides information about a position around an object goal

--- a/habitat/tasks/nav/object_nav_task.py
+++ b/habitat/tasks/nav/object_nav_task.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 from typing import Any, List, Optional
 
 import attr
@@ -27,9 +28,15 @@ from habitat.tasks.nav.nav import (
 class ObjectGoalNavEpisode(NavigationEpisode):
     r"""ObjectGoal Navigation Episode
 
-    :param goals_key: Key to retrieve goals with
+    :param object_category: Category of the obect
     """
-    goals_key: Optional[str] = None
+    object_category: Optional[str] = None
+
+    @property
+    def goals_key(self) -> str:
+        r"""The key to retrieve the goals
+        """
+        return f"{os.path.basename(self.scene_id)}_{self.object_category}"
 
 
 @attr.s(auto_attribs=True)
@@ -130,7 +137,7 @@ class ObjectGoalSensor(Sensor):
         self,
         observations,
         *args: Any,
-        episode: NavigationEpisode,
+        episode: ObjectGoalNavEpisode,
         **kwargs: Any,
     ) -> Optional[int]:
         if self.config.GOAL_SPEC == "TASK_CATEGORY_ID":
@@ -144,7 +151,7 @@ class ObjectGoalSensor(Sensor):
                     f"First goal should be ObjectGoal, episode {episode.episode_id}."
                 )
                 return None
-            category_name = episode.goals[0].object_category
+            category_name = episode.object_category
             return np.array(
                 [self._dataset.category_to_task_category_id[category_name]],
                 dtype=np.int64,

--- a/habitat/tasks/nav/object_nav_task.py
+++ b/habitat/tasks/nav/object_nav_task.py
@@ -29,7 +29,7 @@ class ObjectGoalNavEpisode(NavigationEpisode):
 
     :param goals_key: Key to retrieve goals with
     """
-    goals_key: str = None
+    goals_key: Optional[str] = None
 
 
 @attr.s(auto_attribs=True)

--- a/test/test_object_nav_task.py
+++ b/test/test_object_nav_task.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
 import time
 
 import numpy as np
@@ -25,17 +26,20 @@ EPISODES_LIMIT = 6
 
 def check_json_serializaiton(dataset: habitat.Dataset):
     start_time = time.time()
-    json_str = str(dataset.to_json())
+    json_str = dataset.to_json()
     logger.info(
         "JSON conversion finished. {} sec".format((time.time() - start_time))
     )
-    decoded_dataset = dataset.__class__()
+    decoded_dataset = ObjectNavDatasetV1()
     decoded_dataset.from_json(json_str)
-    assert len(decoded_dataset.episodes) > 0
+    assert len(decoded_dataset.episodes) == len(dataset.episodes)
     episode = decoded_dataset.episodes[0]
     assert isinstance(episode, Episode)
-    assert (
-        decoded_dataset.to_json() == json_str
+
+    # The strings won't match exactly as dictionaries don't have an order for the keys
+    # Thus we need to parse the json strings and compare the serialized forms
+    assert json.loads(decoded_dataset.to_json()) == json.loads(
+        json_str
     ), "JSON dataset encoding/decoding isn't consistent"
 
 
@@ -50,6 +54,12 @@ def test_mp3d_object_nav_dataset():
         id_dataset=dataset_config.TYPE, config=dataset_config
     )
     assert dataset
+    dataset.episodes = dataset.episodes[0:EPISODES_LIMIT]
+    dataset.goals_by_category = {
+        k: v
+        for k, v in dataset.goals_by_category.items()
+        if k in {ep.goals_key for ep in dataset.episodes}
+    }
     check_json_serializaiton(dataset)
 
 


### PR DESCRIPTION
## Motivation and Context

The object nav datasets are huge, both on disk and in memory.  This is largely due to the goals being duplicated across different episodes to the same object category.  This PR resolves this by de-duplicating the goals.

Script to dedup current episodes: https://gist.github.com/erikwijmans/49925738798c5ced3d50e12e3d13b491

## How Has This Been Tested

It loads the episodes!

## Types of changes


- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)


