### PR TITLE
DD-PPO stats devices

### DIFF
--- a/habitat_baselines/rl/ddppo/algo/ddppo_trainer.py
+++ b/habitat_baselines/rl/ddppo/algo/ddppo_trainer.py
@@ -227,10 +227,12 @@ class DDPPOTrainer(PPOTrainer):
         batch = None
         observations = None
 
-        current_episode_reward = torch.zeros(self.envs.num_envs, 1)
+        current_episode_reward = torch.zeros(
+            self.envs.num_envs, 1, device=self.device
+        )
         running_episode_stats = dict(
-            count=torch.zeros(self.envs.num_envs, 1),
-            reward=torch.zeros(self.envs.num_envs, 1),
+            count=torch.zeros(self.envs.num_envs, 1, device=self.device),
+            reward=torch.zeros(self.envs.num_envs, 1, device=self.device),
         )
         window_episode_stats = defaultdict(
             lambda: deque(maxlen=ppo_cfg.reward_window_size)


### PR DESCRIPTION
## Motivation and Context

A little bug from #332.  It seems like the 1-process dummy distributed training on the CI doesn't enforce the same requirements on tensors that actually distributed training does.  A note for the future: The CI won't catch everything for distributed training nor with testing with just 1 process!

## How Has This Been Tested

With 8 processes :-)

## Types of changes


- Bug fix (non-breaking change which fixes an issue)

