### PR TITLE
Return 1d array instead of scalar

### DIFF
--- a/habitat/tasks/nav/nav.py
+++ b/habitat/tasks/nav/nav.py
@@ -388,7 +388,7 @@ class ProximitySensor(Sensor):
             low=0.0,
             high=self._max_detection_radius,
             shape=(1,),
-            dtype=np.float,
+            dtype=np.float32,
         )
 
     def get_observation(
@@ -396,8 +396,13 @@ class ProximitySensor(Sensor):
     ):
         current_position = self._sim.get_agent_state().position
 
-        return self._sim.distance_to_closest_obstacle(
-            current_position, self._max_detection_radius
+        return np.array(
+            [
+                self._sim.distance_to_closest_obstacle(
+                    current_position, self._max_detection_radius
+                )
+            ],
+            dtype=np.float32,
         )
 
 


### PR DESCRIPTION
## Motivation and Context

Sensors need to return 1d arrays instead of scalars to work with habitat-baselines correctly.

Closes #342 

## How Has This Been Tested

Locally

## Types of changes


- Bug fix (non-breaking change which fixes an issue)