### PR TITLE
Fix gradient reduction

### DIFF
--- a/habitat_baselines/rl/ddppo/algo/ddppo.py
+++ b/habitat_baselines/rl/ddppo/algo/ddppo.py
@@ -92,6 +92,5 @@ class DecentralizedDistributedMixin:
             self.reducer.prepare_for_backward([])
 
 
-# Mixin goes second that way the PPO __init__ will still be called
-class DDPPO(PPO, DecentralizedDistributedMixin):
+class DDPPO(DecentralizedDistributedMixin, PPO):
     pass


### PR DESCRIPTION
## Motivation and Context

The Mixin order in DD-PPO is wrong.  I have no idea how this escaped my testing when creating the public release, but it did.

Closes #346 

## How Has This Been Tested

Re-checked, `self.reducer.prepare_for_backward` now gets called and re-verified that gradients are the same across all ranks.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
