### PR TITLE
Update demo notebook (habitat.utils.common import).

### DIFF
--- a/docs/pages/habitat-api-demo.rst
+++ b/docs/pages/habitat-api-demo.rst
@@ -109,9 +109,9 @@ override parameters and freeze the config.
 .. code:: py
     :class: m-console-wrap
 
-    from PIL import Image
-    from habitat_sim.utils import d3_40_colors_rgb
     import numpy as np
+    from PIL import Image
+    from habitat_sim.utils.common import d3_40_colors_rgb
 
     def display_sample(rgb_obs, semantic_obs, depth_obs):
         rgb_img = Image.fromarray(rgb_obs, mode="RGB")

--- a/docs/pages/habitat-sim-demo.rst
+++ b/docs/pages/habitat-sim-demo.rst
@@ -175,7 +175,7 @@ Habitat Sim Demo
 .. code:: py
 
     from PIL import Image
-    from habitat_sim.utils import d3_40_colors_rgb
+    from habitat_sim.utils.common import d3_40_colors_rgb
 
     def display_sample(rgb_obs, semantic_obs, depth_obs):
         rgb_img = Image.fromarray(rgb_obs, mode="RGBA")


### PR DESCRIPTION
## Motivation and Context

The Jupyter notebooks with Habitat API and Habitat Sim demos raise an import error (line `from habitat_sim.utils import d3_40_colors_rgb`) as of 31 March 2020. Demo links (docs):

  1. https://aihabitat.org/docs/habitat-api/habitat-api-demo.html
  2. https://aihabitat.org/docs/habitat-api/habitat-sim-demo.html

It looks like this import was for an older API version and there were breaking changes since last demo update.

## How Has This Been Tested

Tried out the notebooks locally, and there are no more import errors. Note that I only fixed it in docs, these pages have a link to download the Jupyter notebook, which hasn't been changed (I do not have access to it). Please reflect changes of this PR to update two files (so users download the corrected version):

1. https://dl.fbaipublicfiles.com/habitat/notebooks/habitat-sim-demo.ipynb
2. https://dl.fbaipublicfiles.com/habitat/notebooks/habitat-api-demo.ipynb

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
