### PR TITLE
Always provide device in batch_obs

### DIFF
--- a/habitat_baselines/agents/ppo_agents.py
+++ b/habitat_baselines/agents/ppo_agents.py
@@ -116,9 +116,7 @@ class PPOAgent(Agent):
         )
 
     def act(self, observations):
-        batch = batch_obs([observations])
-        for sensor in batch:
-            batch[sensor] = batch[sensor].to(self.device)
+        batch = batch_obs([observations], device=self.device)
 
         with torch.no_grad():
             (

--- a/habitat_baselines/rl/ddppo/algo/ddppo_trainer.py
+++ b/habitat_baselines/rl/ddppo/algo/ddppo_trainer.py
@@ -189,7 +189,7 @@ class DDPPOTrainer(PPOTrainer):
             )
 
         observations = self.envs.reset()
-        batch = batch_obs(observations)
+        batch = batch_obs(observations, device=self.device)
 
         obs_space = self.envs.observation_spaces[0]
         if self._static_encoder:

--- a/habitat_baselines/rl/ppo/ppo_trainer.py
+++ b/habitat_baselines/rl/ppo/ppo_trainer.py
@@ -184,7 +184,7 @@ class PPOTrainer(BaseRLTrainer):
         env_time += time.time() - t_step_env
 
         t_update_stats = time.time()
-        batch = batch_obs(observations)
+        batch = batch_obs(observations, device=self.device)
         rewards = torch.tensor(
             rewards, dtype=torch.float, device=current_episode_reward.device
         )
@@ -294,7 +294,7 @@ class PPOTrainer(BaseRLTrainer):
         rollouts.to(self.device)
 
         observations = self.envs.reset()
-        batch = batch_obs(observations)
+        batch = batch_obs(observations, device=self.device)
 
         for sensor in rollouts.observations:
             rollouts.observations[sensor][0].copy_(batch[sensor])
@@ -470,7 +470,7 @@ class PPOTrainer(BaseRLTrainer):
         self.actor_critic = self.agent.actor_critic
 
         observations = self.envs.reset()
-        batch = batch_obs(observations, self.device)
+        batch = batch_obs(observations, device=self.device)
 
         current_episode_reward = torch.zeros(
             self.envs.num_envs, 1, device=self.device
@@ -525,7 +525,7 @@ class PPOTrainer(BaseRLTrainer):
             observations, rewards, dones, infos = [
                 list(x) for x in zip(*outputs)
             ]
-            batch = batch_obs(observations, self.device)
+            batch = batch_obs(observations, device=self.device)
 
             not_done_masks = torch.tensor(
                 [[0.0] if done else [1.0] for done in dones],


### PR DESCRIPTION
## Motivation and Context

`.copy_` has the same issue with uint8 -> float32 conversion as described in #297.  We had some instances of `batch_obs` that didn't specify the device, so the uint8 to float32 conversion was happening on the CPU instead of the GPU, killing the frame rate.

## How Has This Been Tested

Locally -- bumps FPS when using RGB.
