### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           command: |
               if [ ! -d ~/miniconda ]
               then
-                curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+                curl -o ~/miniconda.sh -O  https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
                 chmod +x ~/miniconda.sh
                 ~/miniconda.sh -b -p $HOME/miniconda
                 rm ~/miniconda.sh


### PR DESCRIPTION
## Motivation and Context

Different URL is now needed for downloading the miniconda installer.
