### PR TITLE
Remove caching for the next time we see an episode

### DIFF
--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -197,6 +197,12 @@ class Env:
 
         assert len(self.episodes) > 0, "Episodes list is empty"
 
+        # Delete the shortest path cache of the current episode
+        # Caching it for the next time we see this episode isn't really worth
+        # it
+        if self._current_episode is not None:
+            self._current_episode._shortest_path_cache = None
+
         self._current_episode = next(self._episode_iterator)
         self.reconfigure(self._config)
 


### PR DESCRIPTION
## Motivation and Context

The shortest path caching currently keeps the cache around for the next time we see an episode.  This isn't really worth it as we see an episode again very infrequently when training on the full dataset, so the extra memory usage isn't worth it.

## How Has This Been Tested

Memory usage is a constant (module scene switches) with this change.

## Types of changes


- Bug fix (non-breaking change which fixes an issue)
