### PR TITLE
Seeding fixes

### DIFF
--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -9,6 +9,7 @@ import time
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 
 import gym
+import numba
 import numpy as np
 from gym.spaces.dict_space import Dict as SpaceDict
 
@@ -260,9 +261,16 @@ class Env:
 
         return observations
 
+    @staticmethod
+    @numba.njit
+    def _seed_numba(seed: int):
+        random.seed(seed)
+        np.random.seed(seed)
+
     def seed(self, seed: int) -> None:
         random.seed(seed)
         np.random.seed(seed)
+        self._seed_numba(seed)
         self._sim.seed(seed)
         self._task.seed(seed)
 

--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -4,6 +4,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import random
 import time
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Type, Union
 
@@ -260,6 +261,8 @@ class Env:
         return observations
 
     def seed(self, seed: int) -> None:
+        random.seed(seed)
+        np.random.seed(seed)
         self._sim.seed(seed)
         self._task.seed(seed)
 

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -30,7 +30,7 @@ def make_env_fn(
         config.TASK_CONFIG.DATASET.TYPE, config=config.TASK_CONFIG.DATASET
     )
     env = env_class(config=config, dataset=dataset)
-    env.seed(self.TASK_CONFIG.SEED + rank)
+    env.seed(config.TASK_CONFIG.SEED + rank)
     return env
 
 

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -30,7 +30,7 @@ def make_env_fn(
         config.TASK_CONFIG.DATASET.TYPE, config=config.TASK_CONFIG.DATASET
     )
     env = env_class(config=config, dataset=dataset)
-    env.seed(rank)
+    env.seed(self.TASK_CONFIG.SEED + rank)
     return env
 
 

--- a/habitat_baselines/run.py
+++ b/habitat_baselines/run.py
@@ -8,6 +8,7 @@ import argparse
 import random
 
 import numpy as np
+import torch
 
 from habitat_baselines.common.baseline_registry import baseline_registry
 from habitat_baselines.config.default import get_config
@@ -53,6 +54,7 @@ def run_exp(exp_config: str, run_type: str, opts=None) -> None:
 
     random.seed(config.TASK_CONFIG.SEED)
     np.random.seed(config.TASK_CONFIG.SEED)
+    torch.manual_seed(config.TASK_CONFIG.SEED)
 
     trainer_init = baseline_registry.get_trainer(config.TRAINER_NAME)
     assert trainer_init is not None, f"{config.TRAINER_NAME} is not supported"


### PR DESCRIPTION
## Motivation and Context

Little misc fixes:

1. Seed np.random, random, and numba in env.seed
1. Actually use the seed in the config for the envs in habitat-baselines
1. Seed torch
1. Slightly better seed generation logic for DD-PPO

## How Has This Been Tested

Existing tests still pass

## Types of changes


- Bug fix (non-breaking change which fixes an issue)
