### PR TITLE
Remove the helper functions for wxyz format

### DIFF
--- a/habitat/utils/geometry_utils.py
+++ b/habitat/utils/geometry_utils.py
@@ -42,15 +42,5 @@ def quaternion_from_two_vectors(v0: np.array, v1: np.array) -> np.quaternion:
     return np.quaternion(s * 0.5, *(axis / s))
 
 
-def quaternion_xyzw_to_wxyz(v: np.array):
-    return np.quaternion(v[3], *v[0:3])
-
-
-def quaternion_wxyz_to_xyzw(v: np.array):
-    return np.quaternion(*v[1:4], v[0])
-
-
 def quaternion_to_list(q: np.quaternion):
-    return quaternion.as_float_array(
-        quaternion_wxyz_to_xyzw(quaternion.as_float_array(q))
-    ).tolist()
+    return q.imag.tolist() + [q.real]

--- a/test/test_mp3d_eqa.py
+++ b/test/test_mp3d_eqa.py
@@ -17,6 +17,8 @@ from habitat.core.logging import logger
 from habitat.datasets import make_dataset
 from habitat.tasks.eqa.eqa import AnswerAction
 from habitat.tasks.nav.nav import MoveForwardAction, StopAction
+from habitat.tasks.utils import quaternion_from_coeff
+from habitat.utils.geometry_utils import angle_between_quaternions
 from habitat.utils.test_utils import sample_non_stop_action
 
 CFG_TEST = "configs/test/habitat_mp3d_eqa_test.yaml"
@@ -237,9 +239,9 @@ def test_mp3d_eqa_sim_correspondence():
                     "cur_state.rotation: {} shortest_path.rotation: {} action: {}"
                     "".format(
                         cur_state.position - point.position,
-                        cur_state.rotation
-                        - habitat.utils.geometry_utils.quaternion_wxyz_to_xyzw(
-                            point.rotation
+                        angle_between_quaternions(
+                            cur_state.rotation,
+                            quaternion_from_coeff(point.rotation),
                         ),
                         cur_state.position,
                         point.position,

--- a/test/test_pointnav_dataset.py
+++ b/test/test_pointnav_dataset.py
@@ -21,7 +21,8 @@ from habitat.datasets.pointnav.pointnav_dataset import (
     DEFAULT_SCENE_PATH_PREFIX,
     PointNavDatasetV1,
 )
-from habitat.utils.geometry_utils import quaternion_xyzw_to_wxyz
+from habitat.tasks.utils import quaternion_from_coeff
+from habitat.utils.geometry_utils import angle_between_quaternions
 
 CFG_TEST = "configs/test/habitat_all_sensors_test.yaml"
 CFG_MULTI_TEST = "configs/datasets/pointnav/gibson.yaml"
@@ -159,8 +160,11 @@ def test_dataset_splitting(split):
 
 def check_shortest_path(env, episode):
     def check_state(agent_state, position, rotation):
-        assert np.allclose(
-            agent_state.rotation, quaternion_xyzw_to_wxyz(rotation)
+        assert (
+            angle_between_quaternions(
+                agent_state.rotation, quaternion_from_coeff(rotation)
+            )
+            < 1e-5
         ), "Agent's rotation diverges from the shortest path."
 
         assert np.allclose(


### PR DESCRIPTION
## Motivation and Context

Habitat is currently fixed on storing quaternions in `xyzw` format.  Determining if a quaternion is in `xyzw` or `wxyz` format is near impossible, so we need to be firm on one format.

## How Has This Been Tested

Just removing un-needed code.  The quaternion to list method is now near-identical to how habitat-sim does it.

## Types of changes


- Docs change / refactoring / dependency upgrade
