### PR TITLE
Build doc in CI, on Python 3.6, taking a shortcut and not building sim docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,6 +200,13 @@ jobs:
               . activate habitat; cd habitat-api
               python setup.py develop --all
 
+              # Download sim inventory for crosslinking (no need to build
+              # the whole sim docs for that)
+              # TODO: take it from github.com/facebookmicrosites/habitat-website
+              #   instead
+              mkdir -p ../habitat-sim/build/docs/habitat-sim
+              curl -s https://aihabitat.org/docs/habitat-sim/objects.inv > ../habitat-sim/build/docs/habitat-sim/objects.inv
+
               cd docs
               conda install -y -c conda-forge doxygen==1.8.16
               conda install -y  jinja2 pygments docutils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,31 +159,11 @@ jobs:
               export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat; cd habitat-sim
               python examples/example.py --scene data/scene_datasets/habitat-test-scenes/van-gogh-room.glb --silent --test_fps_regression $FPS_THRESHOLD
-      - run:
-          name: Build sim documentation
-          command: |
-              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
-              . activate habitat;
-              cd habitat-sim
-              # Rebuild with all options enabled
-              ./build.sh --with-cuda --with-bullet
-              cd docs
-              conda install -y -c conda-forge doxygen==1.8.16
-              conda install -y  jinja2 pygments docutils
-              conda install -y -c conda-forge pelican
-              mkdir -p ../build/docs
-              git submodule update --init
-              ./build-public.sh
       - save_cache:
           key: habitat-sim-{{ checksum "./hsim_sha" }}
           background: true
           paths:
             - ./habitat-sim
-      - save_cache:
-          key: docs-{{ .Branch }}-{{ .Environment.CIRCLE_SHA1 }}
-          background: true
-          paths:
-            - ./habitat-sim/build/docs-public
       - save_cache:
           key: ccache-{{ arch }}-master
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,11 @@ jobs:
                   wget \
                   zip \
                   unzip || true
+              sudo apt install --allow-change-held-packages \
+                  texlive-base \
+                  texlive-latex-extra \
+                  texlive-fonts-extra \
+                  texlive-fonts-recommended
       - run:
           name: Install cuda
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
               # TODO: take it from github.com/facebookmicrosites/habitat-website
               #   instead
               mkdir -p ../habitat-sim/build/docs/habitat-sim
-              curl -s https://aihabitat.org/docs/habitat-sim/objects.inv > ../habitat-sim/build/docs/habitat-sim/objects.inv
+              curl -s https://aihabitat.org/docs/habitat-sim/objects.inv > ../habitat-sim/build/docs-public/habitat-sim/objects.inv
 
               cd docs
               conda install -y -c conda-forge doxygen==1.8.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,17 +196,10 @@ jobs:
       - run:
           name: Build api documentation
           command: |
-              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH              
+              export PATH=$HOME/miniconda/bin:/usr/local/cuda/bin:$PATH
               . activate habitat; cd habitat-api
               python setup.py develop --all
 
-              # NOTE: Temporary workaround for above line while https://github.com/facebookresearch/habitat-api/issues/385 is unresolved
-              # Create conda env with python 3.8 to build habitat-api documentation 
-              conda create -y -n habitat-py38 python=3.8
-              . activate habitat-py38; #cd habitat-api
-              conda install -q -y -c conda-forge ninja numpy pytest pytest-cov ccache hypothesis
-              pip install -r requirements.txt --progress-bar off
-              
               cd docs
               conda install -y -c conda-forge doxygen==1.8.16
               conda install -y  jinja2 pygments docutils

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ jobs:
               # the whole sim docs for that)
               # TODO: take it from github.com/facebookmicrosites/habitat-website
               #   instead
-              mkdir -p ../habitat-sim/build/docs/habitat-sim
+              mkdir -p ../habitat-sim/build/docs-public/habitat-sim
               curl -s https://aihabitat.org/docs/habitat-sim/objects.inv > ../habitat-sim/build/docs-public/habitat-sim/objects.inv
 
               cd docs


### PR DESCRIPTION
## Motivation and Context

Took #393 and made a bunch of changes:

- Python 3.8 is no longer needed, addressed with facebookresearch/habitat-sim#627
- A full build of habitat-sim docs isn't needed, only the `inv` file generated by those which we can download from elsewhere (and if it's stale it's not an issue either, as the docs from here aren't uploaded or used in any way)
- Latex is needed

What would be ideally done is downloading the `inv` file not from aihabitat.org but directly from the habitat-website repo (to avoid the CI jobs failing when the site is not up, when certs expire etc). I wasn't able to convince github to give me that via a plain curl command, would probably need some access tokens etc. Feel free to iterate on this further.

## How Has This Been Tested

Builds green :heavy_check_mark: https://circleci.com/gh/facebookresearch/habitat-api/1855
