### PR TITLE
Cleaned up agent state checks

### DIFF
--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -448,12 +448,7 @@ class HabitatSim(Simulator):
         # state for the sensors. This will cause them to follow the agent's
         # body
         new_state.sensor_states = dict()
-
         agent.set_state(new_state, reset_sensors)
-
-        if not self._check_agent_position(position, agent_id):
-            agent.set_state(original_state, reset_sensors)
-            return False
         return True
 
     def get_observations_at(
@@ -485,13 +480,6 @@ class HabitatSim(Simulator):
             return observations
         else:
             return None
-
-    # TODO(maksymets): Remove check after simulator becomes stable
-    def _check_agent_position(self, position, agent_id=0) -> bool:
-        if not np.allclose(position, self.get_agent_state(agent_id).position):
-            logger.info("Agent state diverges from configured start position.")
-            return False
-        return True
 
     def distance_to_closest_obstacle(self, position, max_search_radius=2.0):
         return self._sim.pathfinder.distance_to_closest_obstacle(


### PR DESCRIPTION
## Motivation and Context
Cleaned up agent state checks as `np.close` method can cause issues and possible breaks. As well as logic changed: we tolerate that new agent's position can differ from the one requested by user as the agent should stand on the plane and can't intersect with other meshes.

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change / refactoring / dependency upgrade
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
