### PR TITLE
docs: remove :ref: as a default role.

### DIFF
--- a/docs/docs.rst
+++ b/docs/docs.rst
@@ -1,11 +1,8 @@
 ..
     Stuff defined here gets set globally for everything else:
 
-    -   use `thing` as a shortcut for :ref:`thing`
     -   use :py:`code` for inline code with highlighted Python syntax
 ..
-
-.. default-role:: ref
 
 .. role:: py(code)
     :language: py

--- a/docs/pages/habitat-api-demo.rst
+++ b/docs/pages/habitat-api-demo.rst
@@ -24,7 +24,7 @@ All the boilerplate code in the habitat-sim to set sensor config and agent
 config is abstracted out in the Habitat-API config system. Default config is at
 :gh:`habitat/config/default.py <facebookresearch/habitat-api/blob/master/habitat/config/default.py>`.
 You can override defaults by specifying them in a separate file and pass it to
-the `habitat.config.get_config()` function or defrost the config object,
+the :ref:`habitat.config.get_config()` function or defrost the config object,
 override parameters and freeze the config.
 
 .. code-figure::

--- a/docs/pages/index.rst
+++ b/docs/pages/index.rst
@@ -7,18 +7,18 @@ tasks, environments, and simulators.
 `Tutorials`_
 ============
 
--   `Quickstart <std:doc:quickstart>`
--   `Habitat Sim Demo <std:doc:habitat-sim-demo>`
--   `Habitat API Demo <std:doc:habitat-api-demo>`
--   `View, Transform and Warp <std:doc:view-transform-warp>`
+-   :ref:`Quickstart <std:doc:quickstart>`
+-   :ref:`Habitat Sim Demo <std:doc:habitat-sim-demo>`
+-   :ref:`Habitat API Demo <std:doc:habitat-api-demo>`
+-   :ref:`View, Transform and Warp <std:doc:view-transform-warp>`
 
 `Package reference`_
 ====================
 
--   `habitat.core.env`
--   `habitat.core.embodied_task`
--   `habitat.core.dataset`
--   `habitat.core.simulator`
--   `habitat.core.vector_env`
--   `habitat.Agent`
--   `habitat.Benchmark`
+-   :ref:`habitat.core.env`
+-   :ref:`habitat.core.embodied_task`
+-   :ref:`habitat.core.dataset`
+-   :ref:`habitat.core.simulator`
+-   :ref:`habitat.core.vector_env`
+-   :ref:`habitat.Agent`
+-   :ref:`habitat.Benchmark`

--- a/habitat/core/agent.py
+++ b/habitat/core/agent.py
@@ -14,7 +14,7 @@ from habitat.core.simulator import Observations
 
 
 class Agent:
-    r"""Abstract class for defining agents which act inside `core.env.Env`.
+    r"""Abstract class for defining agents which act inside :ref:`core.env.Env`.
 
     This abstract class standardizes agents to allow seamless benchmarking.
     """

--- a/habitat/core/dataset.py
+++ b/habitat/core/dataset.py
@@ -47,7 +47,7 @@ class Episode:
         (https://en.wikipedia.org/wiki/Versor). The rotation specifying the
         agent's orientation is relative to the world coordinate axes.
 
-    This information is provided by a `Dataset` instance.
+    This information is provided by a :ref:`Dataset` instance.
     """
 
     episode_id: str = attr.ib(default=None, validator=not_none_validator)
@@ -153,15 +153,15 @@ class Dataset(Generic[T]):
 
     def get_episode_iterator(self, *args: Any, **kwargs: Any) -> Iterator:
         r"""Gets episode iterator with options. Options are specified in
-        `EpisodeIterator` documentation.
+        :ref:`EpisodeIterator` documentation.
 
         :param args: positional args for iterator constructor
         :param kwargs: keyword args for iterator constructor
         :return: episode iterator with specified behavior
 
-        To further customize iterator behavior for your `Dataset` subclass,
-        create a customized iterator class like `EpisodeIterator` and override
-        this method.
+        To further customize iterator behavior for your :ref:`Dataset`
+        subclass, create a customized iterator class like
+        :ref:`EpisodeIterator` and override this method.
         """
         return EpisodeIterator(self.episodes, *args, **kwargs)
 

--- a/habitat/core/embodied_task.py
+++ b/habitat/core/embodied_task.py
@@ -84,15 +84,15 @@ class Measure:
     and task.
 
     :data uuid: universally unique id.
-    :data _metric: metric for the `Measure`, this has to be updated with
-        each `step() <env.Env.step()>` call on `env.Env`.
+    :data _metric: metric for the :ref:`Measure`, this has to be updated with
+        each :ref:`step() <env.Env.step()>` call on :ref:`env.Env`.
 
     This can be used for tracking statistics when running experiments. The
-    user of this class needs to implement the `reset_metric()` and
-    `update_metric()` method and the user is also required to set the
-    `uuid <Measure.uuid>` and `_metric` attributes.
+    user of this class needs to implement the :ref:`reset_metric()` and
+    :ref:`update_metric()` method and the user is also required to set the
+    :ref:`uuid <Measure.uuid>` and :ref:`_metric` attributes.
 
-    .. (uuid is a builtin Python module, so just `uuid` would link there)
+    .. (uuid is a builtin Python module, so just :ref:`uuid` would link there)
     """
 
     _metric: Any
@@ -106,21 +106,21 @@ class Measure:
         raise NotImplementedError
 
     def reset_metric(self, *args: Any, **kwargs: Any) -> None:
-        r"""Reset `_metric`, this method is called from `env.Env` on each
-        reset.
+        r"""Reset :ref:`_metric`, this method is called from :ref:`env.Env` on
+        each reset.
         """
         raise NotImplementedError
 
     def update_metric(self, *args: Any, **kwargs: Any) -> None:
-        r"""Update `_metric`, this method is called from `env.Env` on each
-        `step() <env.Env.step()>`
+        r"""Update :ref:`_metric`, this method is called from :ref:`env.Env`
+        on each :ref:`step() <env.Env.step()>`
         """
         raise NotImplementedError
 
     def get_metric(self):
         r"""..
 
-        :return: the current metric for `Measure`.
+        :return: the current metric for :ref:`Measure`.
         """
         return self._metric
 
@@ -132,7 +132,7 @@ class Metrics(dict):
     def __init__(self, measures: Dict[str, Measure]) -> None:
         """Constructor
 
-        :param measures: list of `Measure` whose metrics are fetched and
+        :param measures: list of :ref:`Measure` whose metrics are fetched and
             packaged.
         """
         data = [
@@ -142,8 +142,8 @@ class Metrics(dict):
 
 
 class Measurements:
-    r"""Represents a set of Measures, with each `Measure` being identified
-    through a unique id.
+    r"""Represents a set of Measures, with each :ref:`Measure` being
+    identified through a unique id.
     """
 
     measures: Dict[str, Measure]
@@ -151,8 +151,8 @@ class Measurements:
     def __init__(self, measures: Iterable[Measure]) -> None:
         """Constructor
 
-        :param measures: list containing `Measure`, uuid of each
-            `Measure` must be unique.
+        :param measures: list containing :ref:`Measure`, uuid of each
+            :ref:`Measure` must be unique.
         """
         self.measures = OrderedDict()
         for measure in measures:
@@ -170,8 +170,8 @@ class Measurements:
             measure.update_metric(*args, **kwargs)
 
     def get_metrics(self) -> Metrics:
-        r"""Collects measurement from all `Measure`\ s and returns it
-        packaged inside `Metrics`.
+        r"""Collects measurement from all :ref:`Measure`\ s and returns it
+        packaged inside :ref:`Metrics`.
         """
         return Metrics(self.measures)
 
@@ -204,10 +204,10 @@ class Measurements:
 class EmbodiedTask:
     r"""Base class for embodied tasks. ``EmbodiedTask`` holds definition of
     a task that agent needs to solve: action space, observation space,
-    measures, simulator usage. ``EmbodiedTask`` has `reset` and `step`
-    methods that are called by ``Env``. ``EmbodiedTask`` is the one of main
-    dimensions for the framework extension. Once new embodied task is
-    introduced implementation of ``EmbodiedTask`` is a formal definition of
+    measures, simulator usage. ``EmbodiedTask`` has :ref:`reset` and
+    :ref:`step` methods that are called by ``Env``. ``EmbodiedTask`` is the
+    one of main dimensions for the framework extension. Once new embodied task
+    is introduced implementation of ``EmbodiedTask`` is a formal definition of
     the task that opens opportunity for others to propose solutions and
     include it into benchmark results.
 

--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -23,16 +23,17 @@ from habitat.tasks import make_task
 
 
 class Env:
-    r"""Fundamental environment class for `habitat`.
+    r"""Fundamental environment class for :ref:`habitat`.
 
     :data observation_space: ``SpaceDict`` object corresponding to sensor in
         sim and task.
     :data action_space: ``gym.space`` object corresponding to valid actions.
 
     All the information  needed for working on embodied tasks with simulator
-    is abstracted inside `Env`. Acts as a base for other derived environment
-    classes. `Env` consists of three major components: ``dataset`` (`episodes`), ``simulator`` (`sim`) and `task` and connects all the three components
-    together.
+    is abstracted inside :ref:`Env`. Acts as a base for other derived
+    environment classes. :ref:`Env` consists of three major components:
+    ``dataset`` (`episodes`), ``simulator`` (:ref:`sim`) and :ref:`task` and
+    connects all the three components together.
     """
 
     observation_space: SpaceDict
@@ -238,10 +239,11 @@ class Env:
     ) -> Observations:
         r"""Perform an action in the environment and return observations.
 
-        :param action: action (belonging to `action_space`) to be performed
-            inside the environment. Action is a name or index of allowed
-            task's action and action arguments (belonging to action's
-            `action_space`) to support parametrized and continuous actions.
+        :param action: action (belonging to :ref:`action_space`) to be
+            performed inside the environment. Action is a name or index of
+            allowed task's action and action arguments (belonging to action's
+            :ref:`action_space`) to support parametrized and continuous
+            actions.
         :return: observations after taking action in environment.
         """
 
@@ -308,9 +310,10 @@ class Env:
 class RLEnv(gym.Env):
     r"""Reinforcement Learning (RL) environment class which subclasses ``gym.Env``.
 
-    This is a wrapper over `Env` for RL users. To create custom RL
+    This is a wrapper over :ref:`Env` for RL users. To create custom RL
     environments users should subclass `RLEnv` and define the following
-    methods: `get_reward_range()`, `get_reward()`, `get_done()`, `get_info()`.
+    methods: :ref:`get_reward_range()`, :ref:`get_reward()`,
+    :ref:`get_done()`, :ref:`get_info()`.
 
     As this is a subclass of ``gym.Env``, it implements `reset()` and
     `step()`.
@@ -323,8 +326,8 @@ class RLEnv(gym.Env):
     ) -> None:
         """Constructor
 
-        :param config: config to construct `Env`
-        :param dataset: dataset to construct `Env`.
+        :param config: config to construct :ref:`Env`
+        :param dataset: dataset to construct :ref:`Env`.
         """
 
         self._env = Env(config, dataset)
@@ -365,7 +368,7 @@ class RLEnv(gym.Env):
         :param observations: observations from simulator and task.
         :return: reward after performing the last action.
 
-        This method is called inside the `step()` method.
+        This method is called inside the :ref:`step()` method.
         """
         raise NotImplementedError
 

--- a/habitat/core/simulator.py
+++ b/habitat/core/simulator.py
@@ -202,7 +202,7 @@ class SensorSuite:
 
     def get_observations(self, *args: Any, **kwargs: Any) -> Observations:
         r"""Collects data from all sensors and returns it packaged inside
-            `Observations`.
+        :ref:`Observations`.
         """
         return Observations(self.sensors, *args, **kwargs)
 
@@ -264,12 +264,13 @@ class Simulator:
 
         :param position_a: coordinates of first point.
         :param position_b: coordinates of second point or list of goal points
-        coordinates.
-        :param episode: The episode with these ends points.  This is used for shortest path computation caching
+            coordinates.
+        :param episode: The episode with these ends points.  This is used for
+            shortest path computation caching
         :return:
             the geodesic distance in the cartesian space between points
             :p:`position_a` and :p:`position_b`, if no path is found between
-            the points then `math.inf` is returned.
+            the points then :ref:`math.inf` is returned.
         """
         raise NotImplementedError
 

--- a/habitat/core/vector_env.py
+++ b/habitat/core/vector_env.py
@@ -56,12 +56,12 @@ GET_METRICS = "get_metrics"
 def _make_env_fn(
     config: Config, dataset: Optional[habitat.Dataset] = None, rank: int = 0
 ) -> Env:
-    """Constructor for default habitat `env.Env`.
+    """Constructor for default habitat :ref:`env.Env`.
 
     :param config: configuration for environment.
     :param dataset: dataset for environment.
     :param rank: rank for setting seed of environment
-    :return: `env.Env` / `env.RLEnv` object
+    :return: :ref:`env.Env` / :ref:`env.RLEnv` object
     """
     habitat_env = Env(config=config, dataset=dataset)
     habitat_env.seed(config.SEED + rank)
@@ -98,9 +98,9 @@ class VectorEnv:
         """..
 
         :param make_env_fn: function which creates a single environment. An
-            environment can be of type `env.Env` or `env.RLEnv`
+            environment can be of type :ref:`env.Env` or :ref:`env.RLEnv`
         :param env_fn_args: tuple of tuple of args to pass to the
-            `_make_env_fn`.
+            :ref:`_make_env_fn`.
         :param auto_reset_done: automatically reset the environment when
             done. This functionality is provided for seamless training
             of vectorized environments.
@@ -357,7 +357,7 @@ class VectorEnv:
         r"""Asynchronously step in the environments.
 
         :param data: list of size _num_envs containing keyword arguments to
-            pass to `step` method for each Environment. For example,
+            pass to :ref:`step` method for each Environment. For example,
             :py:`[{"action": "TURN_LEFT", "action_args": {...}}, ...]`.
         """
         # Backward compatibility
@@ -381,7 +381,7 @@ class VectorEnv:
         r"""Perform actions in the vectorized environments.
 
         :param data: list of size _num_envs containing keyword arguments to
-            pass to `step` method for each Environment. For example,
+            pass to :ref:`step` method for each Environment. For example,
             :py:`[{"action": "TURN_LEFT", "action_args": {...}}, ...]`.
         :return: list of outputs from the step method of envs.
         """
@@ -525,12 +525,13 @@ class VectorEnv:
 
 
 class ThreadedVectorEnv(VectorEnv):
-    r"""Provides same functionality as `VectorEnv`, the only difference is it
-    runs in a multi-thread setup inside a single process.
+    r"""Provides same functionality as :ref:`VectorEnv`, the only difference
+    is it runs in a multi-thread setup inside a single process.
 
-    `VectorEnv` runs in a multi-proc setup. This makes it much easier to debug
-    when using `VectorEnv` because you can actually put break points in the
-    environment methods. It should not be used for best performance.
+    The :ref:`VectorEnv` runs in a multi-proc setup. This makes it much easier
+    to debug when using :ref:`VectorEnv` because you can actually put break
+    points in the environment methods. It should not be used for best
+    performance.
     """
 
     def _spawn_workers(

--- a/habitat/sims/habitat_simulator/actions.py
+++ b/habitat/sims/habitat_simulator/actions.py
@@ -33,7 +33,7 @@ class HabitatSimActionsSingleton(metaclass=Singleton):
     be removed nor can their mapping be altered. This also ensures that all
     actions are always contigously mapped in :py:`[0, len(HabitatSimActions) - 1]`
 
-    This accesible as the global singleton `HabitatSimActions`
+    This accesible as the global singleton :ref:`HabitatSimActions`
     """
 
     _known_actions: Dict[str, int] = attr.ib(init=False, factory=dict)

--- a/habitat/sims/habitat_simulator/habitat_simulator.py
+++ b/habitat/sims/habitat_simulator/habitat_simulator.py
@@ -31,8 +31,9 @@ RGBSENSOR_DIMENSION = 3
 
 def overwrite_config(config_from: Config, config_to: Any) -> None:
     r"""Takes Habitat-API config and Habitat-Sim config structures. Overwrites
-     Habitat-Sim config with Habitat-API values, where a field name is present
-     in lowercase. Mostly used to avoid `sim_cfg.field = hapi_cfg.FIELD` code.
+    Habitat-Sim config with Habitat-API values, where a field name is present
+    in lowercase. Mostly used to avoid :ref:`sim_cfg.field = hapi_cfg.FIELD`
+    code.
 
     Args:
         config_from: Habitat-API config node.

--- a/habitat/sims/pyrobot/pyrobot.py
+++ b/habitat/sims/pyrobot/pyrobot.py
@@ -157,7 +157,7 @@ class PyRobot(Simulator):
     python3 version. Please refer to the PyRobot repository
     for setting it up. The user will also have to export a
     ROS_PATH environment variable to use this integration,
-    please refer to `habitat.core.utils.try_cv2_import` for
+    please refer to :ref:`habitat.core.utils.try_cv2_import` for
     more details on this.
 
     This abstraction assumes that reality is a simulation
@@ -242,8 +242,8 @@ class PyRobot(Simulator):
 
     def step(self, action, action_params):
         r"""Step in reality. Currently the supported
-        actions are the ones defined in `_locobot_base_action_space`
-        and `_locobot_camera_action_space`. For details on how
+        actions are the ones defined in :ref:`_locobot_base_action_space`
+        and :ref:`_locobot_camera_action_space`. For details on how
         to use these actions please refer to the documentation
         of namesake methods in PyRobot
         (https://github.com/facebookresearch/pyrobot).

--- a/habitat_baselines/config/default.py
+++ b/habitat_baselines/config/default.py
@@ -127,13 +127,14 @@ def get_config(
     opts: Optional[list] = None,
 ) -> CN:
     r"""Create a unified config with default values overwritten by values from
-    `config_paths` and overwritten by options from `opts`.
+    :ref:`config_paths` and overwritten by options from :ref:`opts`.
+
     Args:
         config_paths: List of config paths or string that contains comma
         separated list of config paths.
         opts: Config options (keys, values) in a list (e.g., passed from
-        command line into the config. For example, `opts = ['FOO.BAR',
-        0.5]`. Argument can be used for parameter sweeping or quick tests.
+        command line into the config. For example, ``opts = ['FOO.BAR',
+        0.5]``. Argument can be used for parameter sweeping or quick tests.
     """
     config = _C.clone()
     if config_paths:

--- a/habitat_baselines/rl/ddppo/algo/ddp_utils.py
+++ b/habitat_baselines/rl/ddppo/algo/ddp_utils.py
@@ -95,7 +95,7 @@ def load_interrupted_state(filename: str = None) -> Optional[Any]:
 
 
 def requeue_job():
-    r"""Requeues the job by calling `scontrol requeue ${SLURM_JOBID}`
+    r"""Requeues the job by calling ``scontrol requeue ${SLURM_JOBID}``
     """
     if SLURM_JOBID is None:
         return
@@ -118,7 +118,7 @@ def init_distrib_slurm(
     backend: str = "nccl",
 ) -> Tuple[int, torch.distributed.TCPStore]:
     r"""Initializes torch.distributed by parsing environment variables set
-        by SLURM when `srun` is used or by parsing environment variables set
+        by SLURM when ``srun`` is used or by parsing environment variables set
         by torch.distributed.launch
 
     :param backend: Which torch.distributed backend to use


### PR DESCRIPTION
## Motivation and Context

It was originally done so single backticks work for creating references to other parts of the documentation, but having it available globally relied on a hack that wasn't working reliably. Reverting this and using `:ref:` explicitly everywhere until m.css gets a robust way to do this.

Also while at it fixed #397, a bunch of (but certainly not all) markup / documentation errors. A lot of the docsstrings isn't formatted properly and some referenced APIs aren't even exposed in the output, but that would require someone going file-by-file and checking the generated output.

## How Has This Been Tested

Docs build locally with links working as they should.

![image](https://user-images.githubusercontent.com/344828/81935522-0ca4b800-95f1-11ea-8cea-94bd0c7dca81.png)
