### PR TITLE
Seed fix for dataset

### DIFF
--- a/habitat/config/default.py
+++ b/habitat/config/default.py
@@ -40,6 +40,7 @@ _C.ENVIRONMENT.ITERATOR_OPTIONS.NUM_EPISODE_SAMPLE = -1
 _C.ENVIRONMENT.ITERATOR_OPTIONS.MAX_SCENE_REPEAT_EPISODES = -1
 _C.ENVIRONMENT.ITERATOR_OPTIONS.MAX_SCENE_REPEAT_STEPS = int(1e4)
 _C.ENVIRONMENT.ITERATOR_OPTIONS.STEP_REPETITION_RANGE = 0.2
+_C.ENVIRONMENT.ITERATOR_OPTIONS.SEED = _C.SEED
 # -----------------------------------------------------------------------------
 # TASK
 # -----------------------------------------------------------------------------

--- a/habitat/config/default.py
+++ b/habitat/config/default.py
@@ -40,7 +40,6 @@ _C.ENVIRONMENT.ITERATOR_OPTIONS.NUM_EPISODE_SAMPLE = -1
 _C.ENVIRONMENT.ITERATOR_OPTIONS.MAX_SCENE_REPEAT_EPISODES = -1
 _C.ENVIRONMENT.ITERATOR_OPTIONS.MAX_SCENE_REPEAT_STEPS = int(1e4)
 _C.ENVIRONMENT.ITERATOR_OPTIONS.STEP_REPETITION_RANGE = 0.2
-_C.ENVIRONMENT.ITERATOR_OPTIONS.SEED = _C.SEED
 # -----------------------------------------------------------------------------
 # TASK
 # -----------------------------------------------------------------------------

--- a/habitat/core/dataset.py
+++ b/habitat/core/dataset.py
@@ -345,6 +345,7 @@ class EpisodeIterator(Iterator):
         max_scene_repeat_steps: int = -1,
         num_episode_sample: int = -1,
         step_repetition_range: float = 0.2,
+        seed: int = None,
     ):
         r"""..
 
@@ -367,6 +368,9 @@ class EpisodeIterator(Iterator):
             on each scene switch.  This stops all workers from swapping scenes at
             the same time
         """
+        if seed:
+            random.seed(seed)
+            np.random.seed(seed)
 
         # sample episodes
         if num_episode_sample >= 0:

--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -83,7 +83,7 @@ class Env:
             k.lower(): v
             for k, v in config.ENVIRONMENT.ITERATOR_OPTIONS.items()
         }
-        iter_option_dict['seed'] = config.SEED
+        iter_option_dict["seed"] = config.SEED
         self._episode_iterator = self._dataset.get_episode_iterator(
             **iter_option_dict
         )

--- a/habitat/core/env.py
+++ b/habitat/core/env.py
@@ -83,6 +83,7 @@ class Env:
             k.lower(): v
             for k, v in config.ENVIRONMENT.ITERATOR_OPTIONS.items()
         }
+        iter_option_dict['seed'] = config.SEED
         self._episode_iterator = self._dataset.get_episode_iterator(
             **iter_option_dict
         )

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -5,8 +5,9 @@
 # LICENSE file in the root directory of this source tree.
 
 import random
-import numpy as np
 from typing import Type, Union
+
+import numpy as np
 
 import habitat
 from habitat import Config, Env, RLEnv, VectorEnv, make_dataset
@@ -29,7 +30,7 @@ def make_env_fn(
     """
     random.seed(config.TASK_CONFIG.SEED + rank)
     np.random.seed(config.TASK_CONFIG.SEED + rank)
-    
+
     dataset = make_dataset(
         config.TASK_CONFIG.DATASET.TYPE, config=config.TASK_CONFIG.DATASET
     )

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -28,11 +28,9 @@ def make_env_fn(
     Returns:
         env object created according to specification.
     """
-
     dataset = make_dataset(
         config.TASK_CONFIG.DATASET.TYPE, config=config.TASK_CONFIG.DATASET
     )
-
     env = env_class(config=config, dataset=dataset)
     env.seed(config.TASK_CONFIG.SEED + rank)
     return env

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -28,12 +28,16 @@ def make_env_fn(
     Returns:
         env object created according to specification.
     """
-    random.seed(config.TASK_CONFIG.SEED + rank)
-    np.random.seed(config.TASK_CONFIG.SEED + rank)
 
     dataset = make_dataset(
         config.TASK_CONFIG.DATASET.TYPE, config=config.TASK_CONFIG.DATASET
     )
+
+    # Set the seed for the environment iterator before it's initialized in env.
+    config.TASK_CONFIG.ENVIRONMENT.ITERATOR_OPTIONS.SEED = (
+        config.TASK_CONFIG.SEED + rank
+    )
+
     env = env_class(config=config, dataset=dataset)
     env.seed(config.TASK_CONFIG.SEED + rank)
     return env

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -33,11 +33,6 @@ def make_env_fn(
         config.TASK_CONFIG.DATASET.TYPE, config=config.TASK_CONFIG.DATASET
     )
 
-    # Set the seed for the environment iterator before it's initialized in env.
-    config.TASK_CONFIG.ENVIRONMENT.ITERATOR_OPTIONS.SEED = (
-        config.TASK_CONFIG.SEED + rank
-    )
-
     env = env_class(config=config, dataset=dataset)
     env.seed(config.TASK_CONFIG.SEED + rank)
     return env
@@ -100,6 +95,11 @@ def construct_envs(
         )
 
         task_config.SIMULATOR.AGENT_0.SENSORS = config.SENSORS
+
+        # Set the seed for the environment iterator before it's initialized in env.
+        task_config.ENVIRONMENT.ITERATOR_OPTIONS.SEED = (
+            config.TASK_CONFIG.SEED + i
+        )
 
         proc_config.freeze()
         configs.append(proc_config)

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import random
+import numpy as np
 from typing import Type, Union
 
 import habitat
@@ -26,6 +27,9 @@ def make_env_fn(
     Returns:
         env object created according to specification.
     """
+    random.seed(config.TASK_CONFIG.SEED + rank)
+    np.random.seed(config.TASK_CONFIG.SEED + rank)
+    
     dataset = make_dataset(
         config.TASK_CONFIG.DATASET.TYPE, config=config.TASK_CONFIG.DATASET
     )

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -14,7 +14,7 @@ from habitat import Config, Env, RLEnv, VectorEnv, make_dataset
 
 
 def make_env_fn(
-    config: Config, env_class: Type[Union[Env, RLEnv]], rank: int
+    config: Config, env_class: Type[Union[Env, RLEnv]]
 ) -> Union[Env, RLEnv]:
     r"""Creates an env of type env_class with specified config and rank.
     This is to be passed in as an argument when creating VectorEnv.
@@ -23,7 +23,6 @@ def make_env_fn(
         config: root exp config that has core env config node as well as
             env-specific config node.
         env_class: class type of the env to be created.
-        rank: rank of env to be created (for seeding).
 
     Returns:
         env object created according to specification.
@@ -32,7 +31,7 @@ def make_env_fn(
         config.TASK_CONFIG.DATASET.TYPE, config=config.TASK_CONFIG.DATASET
     )
     env = env_class(config=config, dataset=dataset)
-    env.seed(config.TASK_CONFIG.SEED + rank)
+    env.seed(config.TASK_CONFIG.SEED)
     return env
 
 
@@ -85,6 +84,7 @@ def construct_envs(
         proc_config.defrost()
 
         task_config = proc_config.TASK_CONFIG
+        task_config.SEED = task_config.SEED + i
         if len(scenes) > 0:
             task_config.DATASET.CONTENT_SCENES = scene_splits[i]
 
@@ -105,7 +105,7 @@ def construct_envs(
     envs = habitat.VectorEnv(
         make_env_fn=make_env_fn,
         env_fn_args=tuple(
-            tuple(zip(configs, env_classes, range(num_processes)))
+            tuple(zip(configs, env_classes))
         ),
     )
     return envs

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -94,11 +94,6 @@ def construct_envs(
 
         task_config.SIMULATOR.AGENT_0.SENSORS = config.SENSORS
 
-        # Set the seed for the environment iterator before it's initialized in env.
-        task_config.ENVIRONMENT.ITERATOR_OPTIONS.SEED = (
-            config.TASK_CONFIG.SEED + i
-        )
-
         proc_config.freeze()
         configs.append(proc_config)
 

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -104,8 +104,6 @@ def construct_envs(
 
     envs = habitat.VectorEnv(
         make_env_fn=make_env_fn,
-        env_fn_args=tuple(
-            tuple(zip(configs, env_classes))
-        ),
+        env_fn_args=tuple(tuple(zip(configs, env_classes))),
     )
     return envs


### PR DESCRIPTION
## Motivation and Context
Right now the seed doesn't get fixed before the dataset object is created resulting in unpredictable order of episodes. Setting random and np.random seed before the `make_dataset` fixes it. 

## How Has This Been Tested
Manually tested that list of episodes is the same across runs. 
<!--- Please describe here how your modifications have been tested. -->

## Types of changes
- Fixing the seeds in env_utils.py before the dataset is created. 

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
