### PR TITLE
Signal masking

### DIFF
--- a/habitat/core/vector_env.py
+++ b/habitat/core/vector_env.py
@@ -133,7 +133,9 @@ class VectorEnv:
             self._connection_read_fns,
             self._connection_write_fns,
         ) = self._spawn_workers(  # noqa
-            env_fn_args, make_env_fn
+            env_fn_args,
+            make_env_fn,
+            workers_ignore_signals=workers_ignore_signals,
         )
 
         self._is_closed = False

--- a/habitat_baselines/common/env_utils.py
+++ b/habitat_baselines/common/env_utils.py
@@ -35,19 +35,20 @@ def make_env_fn(
 
 
 def construct_envs(
-    config: Config, env_class: Type[Union[Env, RLEnv]]
+    config: Config,
+    env_class: Type[Union[Env, RLEnv]],
+    workers_ignore_signals: bool = False,
 ) -> VectorEnv:
     r"""Create VectorEnv object with specified config and env class type.
     To allow better performance, dataset are split into small ones for
     each individual env, grouped by scenes.
 
-    Args:
-        config: configs that contain num_processes as well as information
-        necessary to create individual environments.
-        env_class: class type of the envs to be created.
+    :param config: configs that contain num_processes as well as information
+    :param necessary to create individual environments.
+    :param env_class: class type of the envs to be created.
+    :param workers_ignore_signals: Passed to :ref:`habitat.VectorEnv`'s constructor
 
-    Returns:
-        VectorEnv object created according to specification.
+    :return: VectorEnv object created according to specification.
     """
 
     num_processes = config.NUM_PROCESSES
@@ -100,5 +101,6 @@ def construct_envs(
         env_fn_args=tuple(
             tuple(zip(configs, env_classes, range(num_processes)))
         ),
+        workers_ignore_signals=workers_ignore_signals,
     )
     return envs

--- a/habitat_baselines/rl/ddppo/algo/ddppo_trainer.py
+++ b/habitat_baselines/rl/ddppo/algo/ddppo_trainer.py
@@ -168,7 +168,9 @@ class DDPPOTrainer(PPOTrainer):
             self.device = torch.device("cpu")
 
         self.envs = construct_envs(
-            self.config, get_env_class(self.config.ENV_NAME)
+            self.config,
+            get_env_class(self.config.ENV_NAME),
+            workers_ignore_signals=True,
         )
 
         ppo_cfg = self.config.RL.PPO


### PR DESCRIPTION
## Motivation and Context

On some systems/python versions, it appears that python multiprocess does not properly forward the parent's signal mask and then the children to exit immediately on various signal.  This stops preemption/job-resumption from working correctly.

This PR adds an option to have worker subprocesses mask out SIGINT, SIGTERM, SIGUSR2, and SIGUSR1 (which are all typically involved in job preemption with SLURM).

## How Has This Been Tested

Locally.

## Types of changes


- Bug fix (non-breaking change which fixes an issue)
