### PR TITLE
Fixed Habitat-API docs quickstart page

### DIFF
--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -106,7 +106,7 @@ you can install using: :sh:`pip install opencv-python`.
         print("Episode finished after {} steps.".format(count_steps))
 
         if (
-            action == habitat.SimulatorActions.stop
+            action == HabitatSimActions.STOP
             and observations["pointgoal_with_gps_compass"][0] < 0.2
         ):
             print("you successfully navigated to destination point")
@@ -131,7 +131,7 @@ Below is a demo of what the example output will look like:
 .. image:: quickstart.png
 
 For more examples refer to
-:gh:`Habitat-API examples <facebookresearch/habitat-sim/tree/master/examples>`
+:gh:`Habitat-API examples <facebookresearch/habitat-api/tree/master/examples>`
 and :gh:`Habitat-Sim examples <facebookresearch/habitat-sim/tree/master/examples>`.
 
 


### PR DESCRIPTION
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

1. Example code snippet on the _quickstart_ page produces `AttributeError: module 'habitat' has no attribute 'SimulatorActions'` on pressing the 'f' key.
2. `Habitat-API examples` references Habitat-Sim examples.





## How Has This Been Tested

1. Run fixed example code on my machine and everything works fine.
2. Unable to build the docs locally with and without my changes. I'm getting ``` `File "./m.css/documentation/doxygen.py", line 252, in extract_id_hash assert id.startswith(state.current_definition_url_base), "ID `%s` does not start with `%s`" % (id, state.current_definition_url_base) AssertionError: ID `dummy_1abfacf16b17cc6a26bb468e8b0f954f63aba2b45bdc11e2a4a6e86aab2ac693cbb` does not start with `SceneNode_8h` ```  when running ./build.sh for docs. 
That's why I can't verify that the changed link works as expected. 

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
