### PR TITLE
Fix double conversion in examples/new_actions.py

### DIFF
--- a/examples/new_actions.py
+++ b/examples/new_actions.py
@@ -48,7 +48,7 @@ def _strafe_impl(
     )
 
     rotation = habitat_sim.utils.quat_from_angle_axis(
-        np.deg2rad(strafe_angle), habitat_sim.geo.UP
+        strafe_angle, habitat_sim.geo.UP
     )
     move_ax = habitat_sim.utils.quat_rotate_vector(rotation, forward_ax)
 


### PR DESCRIPTION
Fixes a bug in the strafe implementation. Angle get converted to radians twice.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Bugfix
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
