### PR TITLE
Used full installation instructions URLs instead of :gh: .

### DIFF
--- a/docs/pages/quickstart.rst
+++ b/docs/pages/quickstart.rst
@@ -28,7 +28,7 @@ Habitat is a platform for embodied AI research that consists of:
     :gh:`[github-repo] <facebookresearch/habitat-api>`
 
 For installing Habitat-Sim and Habitat-API follow instructions
-:gh:`here <facebookresearch/habitat-api#installation>`.
+`here <https://github.com/facebookresearch/habitat-api#installation>`_.
 
 `Example`_
 ==========
@@ -40,7 +40,7 @@ keys.
 
 For running this example both Habitat-Sim and Habitat-API should be installed
 successfully. The data for scene should also be downloaded (steps to do this
-are provided in the :gh:`installation instructions <facebookresearch/habitat-api#installation>`
+are provided in the `installation instructions <https://github.com/facebookresearch/habitat-api#installation>`_
 of Habitat-API). Running the code below also requires installation of cv2 which
 you can install using: :sh:`pip install opencv-python`.
 


### PR DESCRIPTION

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- Please link to an existing issue here if one exists. -->
<!--- (we recommend to have an existing issue for each pull request) -->

Installation instructions links point to https://github.com/facebookresearch/habitat-api/issues/installation but they should point to https://github.com/facebookresearch/habitat-api#installation instead.

See issue [#436](https://github.com/facebookresearch/habitat-api/issues/436) .


## How Has This Been Tested

<!--- Please describe here how your modifications have been tested. -->
The documentation pages were built locally using `build-public.sh`.
Changed links pointed to the correct URLs. 

## Types of changes

<!--- What types of changes does your code introduce? Leave all the items that apply: -->
- Docs change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have completed my CLA (see **CONTRIBUTING**)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
